### PR TITLE
Update docs for auto-update, native installers, and clone actions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,20 +44,25 @@ pkg/                      Shared Go library
   provider/               Provider API clients + mirror interfaces (GitHub, GitLab, Gitea, Forgejo)
   mirror/                 Push/pull mirror setup, status, guides
   status/                 Clone status checking
+  update/                 Auto-update: version check, download, self-replace
 docs/
   cli-guide.md            CLI quick start
   gui-guide.md            GUI guide
   reference.md            Detailed command & config reference
   developer-guide.md      Build instructions, contributing
   architecture.md         Technical design
+  macos-signing.md        macOS code signing setup
   credentials.md          Credential setup guide
   testing.md              Test levels, fixture format, pre-PR and release checklists
   testing-reference.md    Test inventory, harness internals
   completion.md           Shell completion docs
   diagrams/               Architecture diagrams
 assets/                   Icons, logo, screenshot, VHS tape files
+scripts/
+  installer.iss            Windows Inno Setup installer script
+  appimage/                Linux AppImage support files (desktop, AppRun)
 .githooks/pre-push        Pre-push hook (go vet + unit tests)
-.github/workflows/ci.yml  CI: build, test, release
+.github/workflows/ci.yml  CI: build, test, release (+ installers, DMGs, AppImage)
 json/
   gitbox.schema.json      v2 JSON Schema
   gitbox.jsonc            v2 annotated example (Spanish comments)
@@ -181,6 +186,7 @@ The project has a comprehensive test suite. Read `.claude/context/testing-patter
 | `cmd/cli/` (CLI commands) | `go test ./cmd/cli/` |
 | Credential logic (`pkg/credential/`) | `go test ./pkg/credential/ ./cmd/cli/tui/ ./cmd/cli/` |
 | Config logic (`pkg/config/`) | `go test ./pkg/config/ ./cmd/cli/tui/ ./cmd/cli/` |
+| Update logic (`pkg/update/`) | `go test ./pkg/update/` |
 | Unsure what's affected | `go test ./...` |
 
 **Test levels:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ If you're new to the project, read these in order:
 | [Testing](testing.md) | Test levels, fixture setup, pre-PR and release checklists |
 | [Testing Reference](testing-reference.md) | Full test inventory, harness internals |
 | [Architecture](architecture.md) | Technical design, component diagram |
+| [macOS Signing](macos-signing.md) | Code signing and notarization setup for macOS releases |
 
 ## Reference
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,10 @@ Manages per-repo git identity (`user.name`, `user.email`) with a resolution chai
 
 `EnsureRepoIdentity()` checks each clone's local git config and fixes identity if it diverges from the expected values. `CheckGlobalIdentity()` and `RemoveGlobalIdentity()` handle global `~/.gitconfig` identity — gitbox encourages removing global identity so that per-repo identity (set during clone/reconfigure) is always authoritative.
 
+### pkg/update — Auto-update
+
+Provides version checking and self-update via GitHub Releases. `CheckLatest()` queries the GitHub API (throttled to once per 24h). `DownloadRelease()` fetches the platform-specific artifact and verifies its SHA256 checksum. `Apply()` extracts the zip and replaces binaries in place — on Unix via atomic rename, on Windows by renaming the running binary to `.old` first (`CleanupOldBinary()` removes stale `.old` files on the next startup).
+
 ### pkg/mirror — Repository Mirroring
 
 Handles push and pull mirror setup, status checking, and manual setup guides. Mirrors keep backup copies of repos on another provider without cloning locally.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -17,15 +17,17 @@ This guide walks you through the complete workflow — from a fresh install to a
 - **gitbox** binary — install with the one-liner or [download manually](https://github.com/LuisPalacios/gitbox/releases) or [build from source](developer-guide.md)
 - For GCM accounts: [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) installed. On Linux, GCM browser-based OAuth also needs a display server (X11 or Wayland) — see [credentials.md](credentials.md) for headless alternatives.
 
-### Installing (macOS, Linux, Git Bash)
+### Installing
 
-One command handles download, extraction, quarantine flags, and PATH setup:
+Download the native installer for your platform from [Releases](https://github.com/LuisPalacios/gitbox/releases): `.exe` setup for Windows, `.dmg` for macOS, `.AppImage` for Linux. See the [README](../README.md) for details.
+
+Alternatively, use the bootstrap script (macOS, Linux, Git Bash):
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/LuisPalacios/gitbox/main/scripts/bootstrap.sh)
 ```
 
-Use `--cli-only` to skip the GUI, `--version <tag>` for a specific release, or `--prefix <dir>` to change the install directory (default `~/bin`). See the [README](../README.md) for more examples.
+Use `--cli-only` to skip the GUI, `--version <tag>` for a specific release, or `--prefix <dir>` to change the install directory (default `~/bin`).
 
 ## Step 1: Initialize
 
@@ -282,6 +284,17 @@ gitbox account credential setup github-personal --token
 ```
 
 Token and SSH accounts already have a portable PAT — no extra setup needed. See [credentials.md](credentials.md) for details.
+
+## Updating gitbox
+
+Gitbox checks for updates automatically (once per day in the GUI). From the CLI:
+
+```bash
+gitbox update --check   # just check, no install
+gitbox update           # check and install interactively
+```
+
+The updater downloads the release from GitHub, verifies the SHA256 checksum, and replaces the binaries in place. On Windows, a restart is needed after the update.
 
 ## What's next
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -222,13 +222,33 @@ git tag v1.0.0
 git push origin v1.0.0
 ```
 
-CI injects `-ldflags "-X main.version=<tag> -X main.commit=<sha>"` into both CLI and GUI builds. The release will contain one ZIP per platform with both CLI and GUI binaries:
+CI injects `-ldflags "-X main.version=<tag> -X main.commit=<sha>"` into both CLI and GUI builds.
 
-- `gitbox-win-amd64.zip` — `gitbox.exe` + `GitboxApp.exe`
-- `gitbox-macos-arm64.zip` — `gitbox` + `GitboxApp.app`
-- `gitbox-linux-amd64.zip` — `gitbox` + `GitboxApp`
+### Release assets
 
-> **macOS note:** The GUI app is not codesigned. Users must run `xattr -cr gitbox.app` after downloading.
+Each release produces the following artifacts:
+
+| Asset | Contents |
+| --- | --- |
+| `gitbox-win-amd64.zip` | `gitbox.exe` + `GitboxApp.exe` |
+| `gitbox-win-amd64-setup.exe` | Windows Inno Setup installer (PATH, Start Menu) |
+| `gitbox-macos-arm64.zip` | `gitbox` + `GitboxApp.app` |
+| `gitbox-macos-arm64.dmg` | macOS disk image (drag to Applications) |
+| `gitbox-macos-amd64.zip` | `gitbox` + `GitboxApp.app` |
+| `gitbox-macos-amd64.dmg` | macOS disk image (drag to Applications) |
+| `gitbox-linux-amd64.zip` | `gitbox` + `GitboxApp` |
+| `gitbox-linux-amd64.AppImage` | Self-contained Linux app (CLI + GUI) |
+| `checksums.sha256` | SHA256 hashes for all artifacts |
+
+The Windows installer is built with Inno Setup (`scripts/installer.iss`). macOS DMGs are built with `create-dmg`. The Linux AppImage is built with `appimagetool` using the support files in `scripts/appimage/`.
+
+### macOS code signing
+
+macOS DMGs are currently **unsigned**. Code signing and notarization steps are present in the CI workflow but gated on the `APPLE_CERTIFICATE` secret. See [macos-signing.md](macos-signing.md) for setup instructions. Until signing is configured, macOS users should use the bootstrap script or ZIP downloads, which handle quarantine removal automatically.
+
+### Auto-update
+
+The `pkg/update/` package provides version checking and self-update capabilities. Both the CLI (`gitbox update`) and GUI (background check + banner) use it. The updater downloads the platform-specific artifact from GitHub Releases, verifies the SHA256 checksum, and replaces the binaries in place.
 
 ---
 

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -11,28 +11,26 @@ This guide walks you through everything from first launch to day-to-day use.
 
 ## Prerequisites
 
-Download the app from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page. Pick the right file for your system:
+Download the installer for your platform from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page:
 
-- **Windows** — `gitbox-win-amd64.zip`
-- **macOS (Apple Silicon)** — `gitbox-macos-arm64.zip`
-- **Linux** — `gitbox-linux-amd64.zip`
+- **Windows** — `gitbox-win-amd64-setup.exe` (installer with PATH setup and Start Menu shortcuts)
+- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (drag to Applications)
+- **Linux** — `gitbox-linux-amd64.AppImage` (self-contained, just download and run)
 
-Extract the ZIP and run **GitboxApp** (or `GitboxApp.exe` on Windows).
+Alternatively, download the ZIP archives (`gitbox-<platform>-<arch>.zip`) and extract manually.
 
-> **macOS note:** The app is not signed by Apple. After extracting, open a terminal and run `xattr -cr /path/to/GitboxApp.app` to allow it to launch.
+> **macOS note:** The app is not currently signed by Apple. After mounting the DMG or extracting the ZIP, you may need to right-click the app and select "Open" or run `xattr -cr /path/to/GitboxApp.app` in a terminal.
 
-### Installing on Linux
+### Linux AppImage
 
-Download the latest release, extract, and move the binary to a convenient location:
+Download the AppImage, make it executable, and run:
 
 ```bash
-curl -L -O https://github.com/LuisPalacios/gitbox/releases/download/v1.2.14/gitbox-linux-amd64.zip
-unzip gitbox-linux-amd64.zip -d gitbox-linux-amd64
-chmod +x gitbox-linux-amd64/GitboxApp
-./gitbox-linux-amd64/GitboxApp
+chmod +x gitbox-linux-amd64.AppImage
+./gitbox-linux-amd64.AppImage
 ```
 
-Replace `v1.2.14` with the [latest version](https://github.com/LuisPalacios/gitbox/releases). The GUI requires a desktop environment with a display server (X11 or Wayland).
+The GUI requires a desktop environment with a display server (X11 or Wayland).
 
 ## Step 1: First launch
 
@@ -239,6 +237,21 @@ Click the **gear icon** to open the settings panel:
 - **Run at startup** — launch Gitbox automatically when you log in (platform dependent)
 - **Version** — current app version
 - **Author** — project author and link to the GitHub repository
+
+### Clone actions
+
+Each cloned repo row has a **kebab menu (⋮)** on the right side. Click it to see:
+
+- **Open folder** — opens the clone directory in the OS file manager (Explorer, Finder, or your Linux file manager)
+- **Open in \<editor\>** — opens the clone folder in a detected code editor (VS Code, Cursor, Zed, etc.)
+
+Editors are auto-detected on startup by scanning PATH. Gitbox writes the detected editors to `global.editors` in your config file with their full paths. You can reorder entries or add custom editors by editing the config — the menu always reflects the config order.
+
+In **compact mode**, the clone actions appear as two small icon buttons (folder and editor) that show on hover over each repo row. Only the first configured editor is shown — switch to full view for the complete list.
+
+### Update banner
+
+Gitbox checks for updates once per day in the background. When a newer version is available, a green banner appears below the header bar showing the new version. Click **Update** to download and apply it in place. After the update completes, restart the app to use the new version.
 
 ### Deleting repos and accounts
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -509,6 +509,21 @@ See [completion.md](completion.md) for detailed setup instructions.
 
 ---
 
+## Auto-update
+
+Gitbox can check for and apply updates from GitHub releases.
+
+```bash
+gitbox update           # check and install interactively
+gitbox update --check   # just check, no install (exit code 0 = up to date)
+```
+
+The updater downloads the platform-specific artifact, verifies the SHA256 checksum (if `checksums.sha256` is present in the release), and replaces the binaries in place. On Windows, the running binary is renamed to `.old` and cleaned up on the next startup.
+
+The GUI checks for updates automatically once per 24 hours and shows a banner when a newer version is available.
+
+---
+
 ## Configuration file reference
 
 The config lives at `~/.config/gitbox/gitbox.json`. See [gitbox.jsonc](../json/gitbox.jsonc) for a fully annotated example.
@@ -526,6 +541,9 @@ The config lives at `~/.config/gitbox/gitbox.json`. See [gitbox.jsonc](../json/g
 | `credential_gcm.helper`           | string | No       | Credential helper. Typically `"manager"`.                                |
 | `credential_gcm.credential_store` | string | No       | `"wincredman"`, `"keychain"`, or `"secretservice"`.                      |
 | `credential_token`                | object | No       | Token/PAT platform defaults. Presence indicates token auth is available. |
+| `editors`                         | array  | No       | Code editors for the "Open in" menu. Auto-populated on first launch.     |
+| `editors[].name`                  | string | Yes      | Display name (e.g. `"VS Code"`).                                         |
+| `editors[].command`               | string | Yes      | Full path or command name (e.g. `"C:\\...\\code.cmd"`).                   |
 
 ### Account
 

--- a/docs/testing-reference.md
+++ b/docs/testing-reference.md
@@ -111,8 +111,9 @@ Real provider API calls and git operations via subprocess:
 - `pkg/mirror/` — 5 tests: mirror discovery
 - `pkg/provider/` — 35 tests: HTTP client, provider API parsing
 - `pkg/status/` — 8 tests: clone status checking
+- `pkg/update/` — 6 tests: semver parsing, version comparison, update check (mock API), throttle, checksum verification
 
-### Total: ~208 tests
+### Total: ~214 tests
 
 ## How the test harness works
 

--- a/readme.md
+++ b/readme.md
@@ -72,25 +72,35 @@ Gitbox ships as two binaries built from the same Go library (`pkg/`). The CLI an
 > [!WARNING]
 > **Gitbox is not signed or notarized.** The binaries are not code-signed, so macOS Gatekeeper, Windows SmartScreen, and similar OS protections will flag them. The bootstrap installer removes these flags automatically (`xattr -cr` on macOS, `Unblock-File` on Windows) so the binaries can run. **You are explicitly trusting unsigned code when you do this.** I recommend you audit the [source code](https://github.com/LuisPalacios/gitbox) and the [bootstrap script](scripts/bootstrap.sh) before running anything. This project is MIT-licensed open source — inspect it, build it yourself, or don't use it at all.
 
-### Automatic Install
+### Install with native installer
 
-The fastest way to install on macOS, Linux, or Windows (Git Bash) — one command handles the download, extraction, quarantine flags, and PATH setup:
+Download the installer for your platform from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page:
+
+| Platform | Installer | What it does |
+| --- | --- | --- |
+| Windows | `gitbox-win-amd64-setup.exe` | Installs to Program Files, adds to PATH, creates Start Menu shortcuts |
+| macOS | `gitbox-macos-arm64.dmg` / `gitbox-macos-amd64.dmg` | Drag GitboxApp to Applications, CLI included inside the DMG |
+| Linux | `gitbox-linux-amd64.AppImage` | Self-contained, runs directly — no installation needed |
+
+Each release also includes a `checksums.sha256` file for verifying downloads.
+
+Once installed, gitbox checks for updates automatically (once per day). Run `gitbox update` from the CLI or click "Update" in the GUI banner when a new version is available.
+
+### Alternative: bootstrap script
+
+For macOS, Linux, or Windows (Git Bash) — a single command that downloads, extracts, and sets up PATH:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/LuisPalacios/gitbox/main/scripts/bootstrap.sh)
 ```
 
-> The installer supports additional options, add ` --help` at the end to view them
+This installs to `~/bin/` (macOS GUI goes to `/Applications/`). Run with `--help` for options. Useful for headless servers or CI environments where the native installer is not practical.
 
-Note: On macOS the CLI goes to `~/bin/gitbox` and the GUI to `/Applications/GitboxApp.app`. On Linux and Windows both go to `~/bin/`. The script adds `~/bin` to your PATH if needed.
+### Manual install (zip)
 
-### Manual install
+The [Releases](https://github.com/LuisPalacios/gitbox/releases) page also has platform zips (`gitbox-<platform>-<arch>.zip`) containing the raw binaries. Extract and place them wherever you like. The app is not signed, so the OS will complain the first time.
 
-I prefer the previous automatic installation method, but you can also install it manually by grabing binaries from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page. Each release bundles CLI/TUI and GUI for all platforms. The app is not signed, so the OS will complain the first time.
-
-On macOS `xattr -cr /Applications/GitboxApp.app && xattr -cr ~/bin/gitbox && chmod +x ~/bin/gitbox`. On Windows, SmartScreen shows "Windows protected your PC" on first launch, so click **More info** → **Run anyway**. On Linux just make the binaries executable `chmod +x gitbox GitboxApp`
-
-Example of manual install on macOS:
+On macOS: `xattr -cr GitboxApp.app && xattr -cr gitbox && chmod +x gitbox`. On Windows: SmartScreen shows "Windows protected your PC" — click **More info** → **Run anyway**. On Linux: `chmod +x gitbox GitboxApp`.
 
 <p align="center">
   <img src="assets/screenshot-mac.png" alt="Gitbox on macOS showing GUI and terminal side by side" width="800" />


### PR DESCRIPTION
## Summary

- README: native installers as primary install method, bootstrap as alternative
- CLI/GUI guides: document `gitbox update`, clone actions (kebab menu), update banner
- Reference: auto-update section, `global.editors` config fields
- Developer guide: full release assets table, macOS signing, auto-update
- Architecture, testing reference, CLAUDE.md: add `pkg/update/` entries

Documentation-only changes — no code modified.