### PR TITLE
Add install script and README to macOS DMG

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,7 @@ assets/                   Icons, logo, screenshot, VHS tape files
 scripts/
   installer.iss            Windows Inno Setup installer script
   appimage/                Linux AppImage support files (desktop, AppRun)
+  dmg/                     macOS DMG installer script + README
 .githooks/pre-push        Pre-push hook (go vet + unit tests)
 .claude/
   context/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.command text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
           cp artifacts/cli-binaries/gitbox-darwin-arm64 staging/gitbox
           chmod +x staging/gitbox
           cd staging && unzip ../artifacts/gui-macos-arm64/gitbox-macos-arm64.zip
+          cd ..
+          cp 'scripts/dmg/Install Gitbox.command' staging/
+          cp scripts/dmg/README.txt staging/
+          chmod +x 'staging/Install Gitbox.command'
+          sed -i '' 's/\r$//' 'staging/Install Gitbox.command'
       - name: Import signing certificate
         if: env.APPLE_CERTIFICATE != ''
         env:
@@ -264,11 +269,15 @@ jobs:
         run: |
           create-dmg \
             --volname "gitbox" \
-            --window-pos 200 120 --window-size 600 400 \
+            --window-pos 200 120 --window-size 660 500 \
             --icon-size 100 \
-            --icon "GitboxApp.app" 150 190 \
-            --app-drop-link 450 190 \
+            --icon "GitboxApp.app" 150 170 \
+            --app-drop-link 450 170 \
             --hide-extension "GitboxApp.app" \
+            --icon "Install Gitbox.command" 150 370 \
+            --hide-extension "Install Gitbox.command" \
+            --icon "README.txt" 450 370 \
+            --icon "gitbox" 900 900 \
             release/gitbox-macos-arm64.dmg staging/ || test $? -eq 2
       - name: Notarize DMG
         if: env.APPLE_CERTIFICATE != ''
@@ -304,6 +313,11 @@ jobs:
           cp artifacts/cli-binaries/gitbox-darwin-amd64 staging/gitbox
           chmod +x staging/gitbox
           cd staging && unzip ../artifacts/gui-macos-amd64/gitbox-macos-amd64.zip
+          cd ..
+          cp 'scripts/dmg/Install Gitbox.command' staging/
+          cp scripts/dmg/README.txt staging/
+          chmod +x 'staging/Install Gitbox.command'
+          sed -i '' 's/\r$//' 'staging/Install Gitbox.command'
       - name: Import signing certificate
         if: env.APPLE_CERTIFICATE != ''
         env:
@@ -328,11 +342,15 @@ jobs:
         run: |
           create-dmg \
             --volname "gitbox" \
-            --window-pos 200 120 --window-size 600 400 \
+            --window-pos 200 120 --window-size 660 500 \
             --icon-size 100 \
-            --icon "GitboxApp.app" 150 190 \
-            --app-drop-link 450 190 \
+            --icon "GitboxApp.app" 150 170 \
+            --app-drop-link 450 170 \
             --hide-extension "GitboxApp.app" \
+            --icon "Install Gitbox.command" 150 370 \
+            --hide-extension "Install Gitbox.command" \
+            --icon "README.txt" 450 370 \
+            --icon "gitbox" 900 900 \
             release/gitbox-macos-amd64.dmg staging/ || test $? -eq 2
       - name: Notarize DMG
         if: env.APPLE_CERTIFICATE != ''

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -233,18 +233,18 @@ Each release produces the following artifacts:
 | `gitbox-win-amd64.zip` | `gitbox.exe` + `GitboxApp.exe` |
 | `gitbox-win-amd64-setup.exe` | Windows Inno Setup installer (PATH, Start Menu) |
 | `gitbox-macos-arm64.zip` | `gitbox` + `GitboxApp.app` |
-| `gitbox-macos-arm64.dmg` | macOS disk image (drag to Applications) |
+| `gitbox-macos-arm64.dmg` | macOS disk image with bundled installer |
 | `gitbox-macos-amd64.zip` | `gitbox` + `GitboxApp.app` |
-| `gitbox-macos-amd64.dmg` | macOS disk image (drag to Applications) |
+| `gitbox-macos-amd64.dmg` | macOS disk image with bundled installer |
 | `gitbox-linux-amd64.zip` | `gitbox` + `GitboxApp` |
 | `gitbox-linux-amd64.AppImage` | Self-contained Linux app (CLI + GUI) |
 | `checksums.sha256` | SHA256 hashes for all artifacts |
 
-The Windows installer is built with Inno Setup (`scripts/installer.iss`). macOS DMGs are built with `create-dmg`. The Linux AppImage is built with `appimagetool` using the support files in `scripts/appimage/`.
+The Windows installer is built with Inno Setup (`scripts/installer.iss`). macOS DMGs are built with `create-dmg` and include a bundled `Install Gitbox.command` script (`scripts/dmg/`) that copies binaries and removes quarantine flags. The Linux AppImage is built with `appimagetool` using the support files in `scripts/appimage/`.
 
 ### macOS code signing
 
-macOS DMGs are currently **unsigned**. Code signing and notarization steps are present in the CI workflow but gated on the `APPLE_CERTIFICATE` secret. See [macos-signing.md](macos-signing.md) for setup instructions. Until signing is configured, macOS users should use the bootstrap script or ZIP downloads, which handle quarantine removal automatically.
+macOS DMGs are currently **unsigned**. Code signing and notarization steps are present in the CI workflow but gated on the `APPLE_CERTIFICATE` secret. See [macos-signing.md](macos-signing.md) for setup instructions. Until signing is configured, the DMG includes a bundled "Install Gitbox" script that handles quarantine removal automatically. Users can also use the bootstrap script or ZIP downloads.
 
 ### Auto-update
 

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -14,12 +14,12 @@ This guide walks you through everything from first launch to day-to-day use.
 Download the installer for your platform from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page:
 
 - **Windows** — `gitbox-win-amd64-setup.exe` (installer with PATH setup and Start Menu shortcuts)
-- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (drag to Applications)
+- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (double-click "Install Gitbox" inside the DMG)
 - **Linux** — `gitbox-linux-amd64.AppImage` (self-contained, just download and run)
 
 Alternatively, download the ZIP archives (`gitbox-<platform>-<arch>.zip`) and extract manually.
 
-> **macOS note:** The app is not currently signed by Apple. After mounting the DMG or extracting the ZIP, you may need to right-click the app and select "Open" or run `xattr -cr /path/to/GitboxApp.app` in a terminal.
+> **macOS note:** The app is not signed by Apple. The DMG includes an "Install Gitbox" script that copies the binaries and removes quarantine flags automatically. If you prefer to install manually, run `xattr -cr /path/to/GitboxApp.app` and `xattr -cr /path/to/gitbox` in a terminal.
 
 ### Linux AppImage
 

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -55,9 +55,9 @@ xcrun stapler staple gitbox-macos-arm64.dmg
 
 ## Unsigned DMGs
 
-Until signing is configured, macOS users will see a Gatekeeper warning when opening the DMG or app. They can:
+Until signing is configured, macOS users will see a Gatekeeper warning when opening the app. They can:
 
-- Right-click the app and select "Open" (bypasses Gatekeeper for that session)
-- Use `xattr -cr GitboxApp.app` to remove the quarantine attribute
+- Double-click "Install Gitbox" inside the DMG — it copies binaries and removes quarantine flags automatically
+- Use `xattr -cr GitboxApp.app` and `xattr -cr gitbox` to remove the quarantine attribute manually
 - Use the `bootstrap.sh` script which handles this automatically
 - Use `gitbox update` from the CLI which replaces binaries without Gatekeeper checks

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Download the installer for your platform from the [Releases](https://github.com/
 | Platform | Installer | What it does |
 | --- | --- | --- |
 | Windows | `gitbox-win-amd64-setup.exe` | Installs to Program Files, adds to PATH, creates Start Menu shortcuts |
-| macOS | `gitbox-macos-arm64.dmg` / `gitbox-macos-amd64.dmg` | Drag GitboxApp to Applications, CLI included inside the DMG |
+| macOS | `gitbox-macos-arm64.dmg` / `gitbox-macos-amd64.dmg` | Double-click "Install Gitbox" in the DMG — installs GUI to Applications, CLI to ~/bin, clears quarantine flags |
 | Linux | `gitbox-linux-amd64.AppImage` | Self-contained, runs directly — no installation needed |
 
 Each release also includes a `checksums.sha256` file for verifying downloads.

--- a/scripts/dmg/Install Gitbox.command
+++ b/scripts/dmg/Install Gitbox.command
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Install Gitbox.command — macOS installer bundled inside the DMG
+# Double-click this file in Finder or run: bash "/Volumes/gitbox/Install Gitbox.command"
+set -euo pipefail
+
+INSTALL_DIR="$HOME/bin"
+APP_DIR="/Applications"
+
+# ── Output helpers ──────────────────────────────────────────────────
+
+red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+
+log()  { green  "[gitbox] $*"; }
+warn() { yellow "[gitbox] $*"; }
+die()  { red    "[gitbox] $*"; exit 1; }
+
+# ── Locate DMG contents ────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+[[ -d "$SCRIPT_DIR/GitboxApp.app" ]] || die "GitboxApp.app not found next to this script."
+[[ -f "$SCRIPT_DIR/gitbox" ]]        || die "gitbox CLI binary not found next to this script."
+
+# ── Confirm ─────────────────────────────────────────────────────────
+
+echo ""
+bold "── gitbox installer ──"
+echo ""
+echo "  This script will:"
+echo "    1. Copy GitboxApp.app  → $APP_DIR/"
+echo "    2. Copy gitbox CLI     → $INSTALL_DIR/"
+echo "    3. Remove quarantine attributes (xattr -cr)"
+echo "    4. Add $INSTALL_DIR to PATH if needed"
+echo ""
+warn "gitbox is NOT signed or notarized by Apple."
+warn "You are trusting unsigned code. Audit the source: https://github.com/LuisPalacios/gitbox"
+echo ""
+printf "  Continue? [Y/n] "
+read -r answer
+case "${answer:-Y}" in
+  [Yy]*) ;;
+  *)     echo "Aborted."; exit 0 ;;
+esac
+
+echo ""
+
+# ── Install GUI ─────────────────────────────────────────────────────
+
+log "Installing GitboxApp.app → $APP_DIR/"
+rm -rf "$APP_DIR/GitboxApp.app"
+cp -R "$SCRIPT_DIR/GitboxApp.app" "$APP_DIR/GitboxApp.app"
+xattr -cr "$APP_DIR/GitboxApp.app" 2>/dev/null || true
+log "Done."
+
+# ── Install CLI ─────────────────────────────────────────────────────
+
+log "Installing gitbox CLI → $INSTALL_DIR/"
+mkdir -p "$INSTALL_DIR"
+cp "$SCRIPT_DIR/gitbox" "$INSTALL_DIR/gitbox"
+chmod +x "$INSTALL_DIR/gitbox"
+xattr -cr "$INSTALL_DIR/gitbox" 2>/dev/null || true
+log "Done."
+
+# ── PATH helper ─────────────────────────────────────────────────────
+
+ensure_path() {
+  local dir="$1"
+  local marker="# gitbox"
+
+  if echo "$PATH" | tr ':' '\n' | grep -qx "$dir"; then
+    return
+  fi
+
+  local rc_file="$HOME/.zshrc"
+  if [[ "$(basename "${SHELL:-/bin/zsh}")" != "zsh" ]]; then
+    rc_file="$HOME/.bashrc"
+  fi
+
+  # Already added by a previous run?
+  if [[ -f "$rc_file" ]] && grep -qF "$marker" "$rc_file"; then
+    return
+  fi
+
+  log "Adding $dir to PATH in $rc_file"
+  printf '\n%s\nexport PATH="%s:$PATH"\n' "$marker" "$dir" >> "$rc_file"
+}
+
+ensure_path "$INSTALL_DIR"
+
+# ── Summary ─────────────────────────────────────────────────────────
+
+echo ""
+bold "── Installation complete ──"
+echo ""
+echo "  GUI:  $APP_DIR/GitboxApp.app"
+echo "  CLI:  $INSTALL_DIR/gitbox"
+echo ""
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  rc_hint="$HOME/.zshrc"
+  if [[ "$(basename "${SHELL:-/bin/zsh}")" != "zsh" ]]; then
+    rc_hint="$HOME/.bashrc"
+  fi
+  bold "  Reload your shell to pick up PATH changes:"
+  echo "    source $rc_hint"
+  echo ""
+fi
+
+bold "  Get started:"
+echo "    gitbox help"
+echo ""

--- a/scripts/dmg/README.txt
+++ b/scripts/dmg/README.txt
@@ -1,0 +1,68 @@
+GITBOX — macOS INSTALLER
+========================
+
+TRUST WARNING
+-------------
+
+Gitbox is NOT signed or notarized by Apple. macOS Gatekeeper will block
+the binaries if you drag-and-drop them manually. By running the bundled
+installer or clearing quarantine attributes yourself, you are explicitly
+trusting unsigned code.
+
+Audit the source before running anything:
+  https://github.com/LuisPalacios/gitbox
+
+This software is provided "as is", without warranty of any kind. See the
+LICENSE file in the repository for full terms.
+
+
+RECOMMENDED: USE THE INSTALLER
+-------------------------------
+
+Double-click "Install Gitbox" in this disk image. A Terminal window will
+open and the script will:
+
+  1. Copy GitboxApp.app to /Applications/
+  2. Copy the gitbox CLI to ~/bin/
+  3. Remove quarantine attributes so macOS allows them to run
+  4. Add ~/bin to your PATH if not already there
+
+The script asks for confirmation before making changes. It does not
+require administrator (sudo) privileges and does not access the network.
+
+Alternatively, from Terminal:
+
+  bash "/Volumes/gitbox/Install Gitbox.command"
+
+
+MANUAL INSTALLATION
+-------------------
+
+If you prefer not to use the script:
+
+  1. Drag GitboxApp.app to /Applications/ (or any folder you like)
+  2. Open Terminal and run:
+
+       xattr -cr /Applications/GitboxApp.app
+
+  3. Copy the gitbox binary to a directory in your PATH:
+
+       cp /Volumes/gitbox/gitbox ~/bin/
+       chmod +x ~/bin/gitbox
+       xattr -cr ~/bin/gitbox
+
+The xattr command removes the quarantine flag that macOS sets on files
+downloaded from the internet. Without it, Gatekeeper will prevent the
+app from launching.
+
+
+GETTING STARTED
+---------------
+
+After installation, run:
+
+  gitbox help
+
+Or launch GitboxApp from /Applications/.
+
+Full documentation: https://github.com/LuisPalacios/gitbox#readme


### PR DESCRIPTION
## Summary

- Bundle an `Install Gitbox.command` script inside the macOS DMG that users can double-click in Finder to install both the GUI and CLI, clear quarantine attributes, and update PATH — no code signing needed
- Add a `README.txt` with trust warnings, manual install steps, and a link to source code for auditing
- Hide the raw `gitbox` CLI binary off-screen in the DMG layout so users go through the installer
- Add `.gitattributes` to enforce LF line endings for shell scripts (dev happens on Windows)

## Test plan

- [ ] CI: verify both `dmg-macos-arm64` and `dmg-macos-amd64` jobs build successfully
- [ ] Mount a built DMG and confirm 4 visible icons: GitboxApp, Applications, Install Gitbox, README.txt
- [ ] Double-click "Install Gitbox" — verify Terminal opens, script runs, files land in `/Applications/` and `~/bin/`
- [ ] Verify `xattr -l /Applications/GitboxApp.app` and `xattr -l ~/bin/gitbox` show no quarantine
- [ ] Run `gitbox version` after install
- [ ] Verify README.txt renders cleanly in Quick Look