### PR TITLE
Fix DMG install instructions for Gatekeeper

### DIFF
--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -14,12 +14,12 @@ This guide walks you through everything from first launch to day-to-day use.
 Download the installer for your platform from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page:
 
 - **Windows** — `gitbox-win-amd64-setup.exe` (installer with PATH setup and Start Menu shortcuts)
-- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (double-click "Install Gitbox" inside the DMG)
+- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (right-click "Install Gitbox" → Open inside the DMG)
 - **Linux** — `gitbox-linux-amd64.AppImage` (self-contained, just download and run)
 
 Alternatively, download the ZIP archives (`gitbox-<platform>-<arch>.zip`) and extract manually.
 
-> **macOS note:** The app is not signed by Apple. The DMG includes an "Install Gitbox" script that copies the binaries and removes quarantine flags automatically. If you prefer to install manually, run `xattr -cr /path/to/GitboxApp.app` and `xattr -cr /path/to/gitbox` in a terminal.
+> **macOS note:** The app is not signed by Apple. The DMG includes an "Install Gitbox" script that copies the binaries and removes quarantine flags automatically. Right-click the script and select "Open" to bypass Gatekeeper, or run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal. For manual install, use `xattr -cr /path/to/GitboxApp.app` and `xattr -cr /path/to/gitbox`.
 
 ### Linux AppImage
 

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -14,12 +14,12 @@ This guide walks you through everything from first launch to day-to-day use.
 Download the installer for your platform from the [Releases](https://github.com/LuisPalacios/gitbox/releases) page:
 
 - **Windows** — `gitbox-win-amd64-setup.exe` (installer with PATH setup and Start Menu shortcuts)
-- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (right-click "Install Gitbox" → Open inside the DMG)
+- **macOS** — `gitbox-macos-arm64.dmg` or `gitbox-macos-amd64.dmg` (open DMG, run the install script from Terminal)
 - **Linux** — `gitbox-linux-amd64.AppImage` (self-contained, just download and run)
 
 Alternatively, download the ZIP archives (`gitbox-<platform>-<arch>.zip`) and extract manually.
 
-> **macOS note:** The app is not signed by Apple. The DMG includes an "Install Gitbox" script that copies the binaries and removes quarantine flags automatically. Right-click the script and select "Open" to bypass Gatekeeper, or run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal. For manual install, use `xattr -cr /path/to/GitboxApp.app` and `xattr -cr /path/to/gitbox`.
+> **macOS note:** The app is not signed by Apple. The DMG includes an "Install Gitbox" script that copies the binaries and removes quarantine flags automatically. Run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal. For manual install, use `xattr -cr /path/to/GitboxApp.app` and `xattr -cr /path/to/gitbox`.
 
 ### Linux AppImage
 

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -57,7 +57,7 @@ xcrun stapler staple gitbox-macos-arm64.dmg
 
 Until signing is configured, macOS users will see a Gatekeeper warning when opening the app. They can:
 
-- Right-click "Install Gitbox" inside the DMG → Open — it copies binaries and removes quarantine flags automatically (or run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal)
+- Run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal — the bundled install script copies binaries and removes quarantine flags automatically
 - Use `xattr -cr GitboxApp.app` and `xattr -cr gitbox` to remove the quarantine attribute manually
 - Use the `bootstrap.sh` script which handles this automatically
 - Use `gitbox update` from the CLI which replaces binaries without Gatekeeper checks

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -57,7 +57,7 @@ xcrun stapler staple gitbox-macos-arm64.dmg
 
 Until signing is configured, macOS users will see a Gatekeeper warning when opening the app. They can:
 
-- Double-click "Install Gitbox" inside the DMG — it copies binaries and removes quarantine flags automatically
+- Right-click "Install Gitbox" inside the DMG → Open — it copies binaries and removes quarantine flags automatically (or run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal)
 - Use `xattr -cr GitboxApp.app` and `xattr -cr gitbox` to remove the quarantine attribute manually
 - Use the `bootstrap.sh` script which handles this automatically
 - Use `gitbox update` from the CLI which replaces binaries without Gatekeeper checks

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Download the installer for your platform from the [Releases](https://github.com/
 | Platform | Installer | What it does |
 | --- | --- | --- |
 | Windows | `gitbox-win-amd64-setup.exe` | Installs to Program Files, adds to PATH, creates Start Menu shortcuts |
-| macOS | `gitbox-macos-arm64.dmg` / `gitbox-macos-amd64.dmg` | Double-click "Install Gitbox" in the DMG — installs GUI to Applications, CLI to ~/bin, clears quarantine flags |
+| macOS | `gitbox-macos-arm64.dmg` / `gitbox-macos-amd64.dmg` | Open DMG, run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal — installs GUI + CLI, clears quarantine flags |
 | Linux | `gitbox-linux-amd64.AppImage` | Self-contained, runs directly — no installation needed |
 
 Each release also includes a `checksums.sha256` file for verifying downloads.

--- a/scripts/dmg/README.txt
+++ b/scripts/dmg/README.txt
@@ -19,8 +19,8 @@ LICENSE file in the repository for full terms.
 RECOMMENDED: USE THE INSTALLER
 -------------------------------
 
-Double-click "Install Gitbox" in this disk image. A Terminal window will
-open and the script will:
+The DMG includes an "Install Gitbox" script that copies the binaries
+and removes quarantine flags automatically. It will:
 
   1. Copy GitboxApp.app to /Applications/
   2. Copy the gitbox CLI to ~/bin/
@@ -30,9 +30,17 @@ open and the script will:
 The script asks for confirmation before making changes. It does not
 require administrator (sudo) privileges and does not access the network.
 
-Alternatively, from Terminal:
+Because this software is not signed, macOS Gatekeeper will also block
+the installer script itself when you double-click it. Two ways to run it:
 
-  bash "/Volumes/gitbox/Install Gitbox.command"
+  Option A — Right-click "Install Gitbox" and select "Open". macOS will
+  show a warning dialog; click "Open" to proceed.
+
+  Option B — Open Terminal and run:
+
+    bash "/Volumes/gitbox/Install Gitbox.command"
+
+  This bypasses Gatekeeper because bash reads the script as a text file.
 
 
 MANUAL INSTALLATION

--- a/scripts/dmg/README.txt
+++ b/scripts/dmg/README.txt
@@ -1,41 +1,24 @@
-GITBOX — macOS INSTALLER
-========================
+GITBOX for macOS
+================
 
-TRUST WARNING
--------------
+HOW TO INSTALL
+--------------
 
-Gitbox is NOT signed or notarized by Apple. macOS Gatekeeper will block
-the binaries if you drag-and-drop them manually. By running the bundled
-installer or clearing quarantine attributes yourself, you are explicitly
-trusting unsigned code.
-
-Audit the source before running anything:
-  https://github.com/LuisPalacios/gitbox
-
-This software is provided "as is", without warranty of any kind. See the
-LICENSE file in the repository for full terms.
-
-
-RECOMMENDED: USE THE INSTALLER
--------------------------------
-
-The DMG includes an "Install Gitbox" script that copies the binaries
-and removes quarantine flags automatically. It will:
-
-  1. Copy GitboxApp.app to /Applications/
-  2. Copy the gitbox CLI to ~/bin/
-  3. Remove quarantine attributes so macOS allows them to run
-  4. Add ~/bin to your PATH if not already there
-
-The script asks for confirmation before making changes. It does not
-require administrator (sudo) privileges and does not access the network.
-
-Because this software is not signed, macOS Gatekeeper blocks the
-installer script too. Open Terminal and run:
+Open Terminal and run:
 
   bash "/Volumes/gitbox/Install Gitbox.command"
 
-This bypasses Gatekeeper because bash reads the script as a text file.
+The script will:
+  - Copy GitboxApp.app to /Applications/
+  - Copy the gitbox CLI to ~/bin/
+  - Remove quarantine attributes so macOS allows them to run
+  - Add ~/bin to your PATH if needed
+
+It asks for confirmation first. No sudo required, no network access.
+
+Why Terminal? This app is not signed by Apple, so macOS Gatekeeper
+blocks everything in this DMG — including the installer script itself.
+Running it through bash bypasses that restriction.
 
 
 MANUAL INSTALLATION
@@ -43,29 +26,40 @@ MANUAL INSTALLATION
 
 If you prefer not to use the script:
 
-  1. Drag GitboxApp.app to /Applications/ (or any folder you like)
+  1. Drag GitboxApp.app to /Applications/
   2. Open Terminal and run:
 
        xattr -cr /Applications/GitboxApp.app
 
-  3. Copy the gitbox binary to a directory in your PATH:
+  3. Copy the CLI binary to a directory in your PATH:
 
+       mkdir -p ~/bin
        cp /Volumes/gitbox/gitbox ~/bin/
        chmod +x ~/bin/gitbox
        xattr -cr ~/bin/gitbox
 
-The xattr command removes the quarantine flag that macOS sets on files
-downloaded from the internet. Without it, Gatekeeper will prevent the
-app from launching.
+The xattr command removes the quarantine flag that macOS sets on
+files downloaded from the internet.
 
 
-GETTING STARTED
----------------
+TRUST WARNING
+-------------
 
-After installation, run:
+Gitbox is NOT signed or notarized by Apple. By running the installer
+or clearing quarantine attributes yourself, you are explicitly trusting
+unsigned code. Audit the source before running anything:
 
-  gitbox help
+  https://github.com/LuisPalacios/gitbox
 
-Or launch GitboxApp from /Applications/.
+This software is provided "as is", without warranty of any kind.
+See the LICENSE file in the repository for full terms.
+
+
+AFTER INSTALLATION
+------------------
+
+  gitbox help               Launch the CLI
+  gitbox                    Launch the TUI (interactive terminal UI)
+  open /Applications/GitboxApp.app   Launch the GUI
 
 Full documentation: https://github.com/LuisPalacios/gitbox#readme

--- a/scripts/dmg/README.txt
+++ b/scripts/dmg/README.txt
@@ -30,17 +30,12 @@ and removes quarantine flags automatically. It will:
 The script asks for confirmation before making changes. It does not
 require administrator (sudo) privileges and does not access the network.
 
-Because this software is not signed, macOS Gatekeeper will also block
-the installer script itself when you double-click it. Two ways to run it:
+Because this software is not signed, macOS Gatekeeper blocks the
+installer script too. Open Terminal and run:
 
-  Option A — Right-click "Install Gitbox" and select "Open". macOS will
-  show a warning dialog; click "Open" to proceed.
+  bash "/Volumes/gitbox/Install Gitbox.command"
 
-  Option B — Open Terminal and run:
-
-    bash "/Volumes/gitbox/Install Gitbox.command"
-
-  This bypasses Gatekeeper because bash reads the script as a text file.
+This bypasses Gatekeeper because bash reads the script as a text file.
 
 
 MANUAL INSTALLATION


### PR DESCRIPTION
## Summary

- macOS Gatekeeper blocks `.command` files from quarantined DMGs too — double-click doesn't work
- Update DMG README.txt to explain two workarounds: right-click → Open, or `bash` from Terminal
- Update docs (README.md, gui-guide.md, macos-signing.md) to say "right-click → Open" instead of "double-click"

## Test plan

- [ ] Mount a DMG, right-click "Install Gitbox" → Open — confirm macOS shows a warning dialog with "Open" button
- [ ] Run `bash "/Volumes/gitbox/Install Gitbox.command"` from Terminal — confirm it runs without Gatekeeper interference