### PR TITLE
Fix update check throttle hiding new releases

### DIFF
--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -67,7 +67,10 @@ func CheckLatest(ctx context.Context, opts Options) (*CheckResult, error) {
 		return nil, err
 	}
 
-	if opts.CacheFile != "" {
+	// Only throttle when an update was found — avoids locking out checks
+	// for 24h after a "no update" result, which would hide a release
+	// published during that window.
+	if opts.CacheFile != "" && result.Available {
 		writeThrottleTimestamp(opts.CacheFile)
 	}
 

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -164,6 +164,81 @@ func TestThrottle(t *testing.T) {
 	}
 }
 
+func TestCheckLatest_NoUpdate_DoesNotThrottle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"tag_name": "v1.0.0", "html_url": "", "assets": []}`)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, ".update-check")
+
+	opts := Options{
+		CurrentVersion: "v1.0.0",
+		Repo:           "test/test",
+		HTTPClient:     srv.Client(),
+		CacheFile:      cacheFile,
+		ThrottleDur:    24 * time.Hour,
+	}
+	opts.HTTPClient.Transport = rewriteTransport{base: http.DefaultTransport, target: srv.URL}
+
+	result, err := CheckLatest(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CheckLatest error: %v", err)
+	}
+	if result.Available {
+		t.Error("expected no update available")
+	}
+
+	// Cache file should NOT exist — no-update results must not throttle.
+	if _, err := os.Stat(cacheFile); err == nil {
+		t.Error("throttle cache written after no-update result; should only cache when update is available")
+	}
+}
+
+func TestCheckLatest_UpdateAvailable_Throttles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"tag_name": "v2.0.0", "html_url": "", "assets": []}`)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, ".update-check")
+
+	opts := Options{
+		CurrentVersion: "v1.0.0",
+		Repo:           "test/test",
+		HTTPClient:     srv.Client(),
+		CacheFile:      cacheFile,
+		ThrottleDur:    24 * time.Hour,
+	}
+	opts.HTTPClient.Transport = rewriteTransport{base: http.DefaultTransport, target: srv.URL}
+
+	result, err := CheckLatest(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CheckLatest error: %v", err)
+	}
+	if !result.Available {
+		t.Error("expected update available")
+	}
+
+	// Cache file SHOULD exist — positive results must throttle.
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Error("throttle cache not written after update-available result")
+	}
+
+	// Second call should be throttled (return nil).
+	result2, err := CheckLatest(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("second CheckLatest error: %v", err)
+	}
+	if result2 != nil {
+		t.Error("expected nil result (throttled) on second call")
+	}
+}
+
 // ── Checksum tests ──
 
 func TestVerifyChecksum(t *testing.T) {


### PR DESCRIPTION
## Summary

- The 24h throttle cache was written after **every** successful GitHub API call, including when no update was available
- This meant a "no update" result at 11:14 blocked re-checks until 11:14 the next day — a release published at 13:31 was invisible
- Fix: only write the throttle timestamp when `result.Available` is true; no-update results don't cache, so the next app launch always re-checks

## Test plan

- [x] `TestCheckLatest_NoUpdate_DoesNotThrottle` — verifies cache file is NOT created after a no-update result
- [x] `TestCheckLatest_UpdateAvailable_Throttles` — verifies cache IS created after an update-available result, and second call is throttled
- [x] All existing update tests pass
- [x] `go vet ./...` clean
- [ ] Manual: install current version, publish a newer release, relaunch app — notification should appear immediately