### PR TITLE
Add branch-aware status and UX across TUI, GUI, and CLI

### DIFF
--- a/.claude/context/feature-radar.md
+++ b/.claude/context/feature-radar.md
@@ -21,13 +21,14 @@ Active feature backlog for gitbox. Managed by the `/wish` skill.
 
 ## Radar
 
-### W2: Bulk branch cleanup (`gitbox sweep`)
+### W7: Branch-aware status and UX
 
 - **Status:** planning
-- **Priority:** P1
+- **Priority:** P2
 - **Size:** M
-- **Concept:** Safely delete local branches that have been merged upstream or removed on the remote, across all repos in a source or across all sources. A `gitbox sweep` CLI command plus a TUI action and GUI panel.
-- **Notes:** Plan: (1) Add git helpers — `DefaultBranch`, `StaleBranches`, `DeleteBranch` in `pkg/git/git.go`. (2) CLI `sweep_cmd.go` following `fetch_cmd.go` pattern with `--source`/`--repo`/`--dry-run` flags. (3) TUI `s` keybinding in `screen_repos.go`. (4) GUI "Sweep branches" in kebab menu via `app.go` + `App.svelte`. (5) Tests for git helpers + CLI subprocess tests.
+- **Concept:** Make gitbox branch-aware across all views. Currently the dashboard (TUI and GUI) shows status relative to the current branch's upstream but never tells the user WHICH branch that is — a repo on `feature-x` that is clean looks identical to one on `main`. Local branches without upstream show alarming `~ No upstream` with no explanation. Detached HEAD is not handled. The fix is pure observability: show a branch badge in dashboard rows only when the current branch differs from default, soften "No upstream" labeling for local branches, handle detached HEAD explicitly, report skipped repos during bulk pull, and stop inflating account issue counts for normal feature-branch work. No new git write operations — gitbox is a fleet observer, not a repo-level client.
+- **Notes:** Plan: (1) Add `Branch string` + `IsDefault bool` to `status.RepoStatus`, populate in `Check()` from existing `git.Status().Branch` + `git.DefaultBranch()`. (2) TUI: branch badge `[feature-x]` in dashboard rows when not on default, soften `formatStatusDetail` for NoUpstream on non-default branch to "local branch", fix `computeAccountStats` to not count feature-branch NoUpstream as issue, detached HEAD display in `screen_repos.go`. (3) GUI: add fields to `StatusResult` + `toStatusResult()` in `app.go`, propagate through `types.ts` → `stores.ts` → `App.svelte`, branch badge in repo rows, "Local branch" vs "No upstream" conditional, fix `accountStats` issue counting. (4) CLI: branch badge in `status_cmd.go`, improved skip reporting in `pull_cmd.go` with branch name. 4 commits: data layer → TUI+CLI → GUI → docs.
+
 
 ### W1: Config sync
 
@@ -62,6 +63,15 @@ Active feature backlog for gitbox. Managed by the `/wish` skill.
 - **Notes:** Requires new API endpoints on each provider implementation (PR listing, review request queries). The provider interface would need a new method (e.g., `PendingReviews`). This is the largest feature — significant API surface area across 5 providers (GitHub, GitLab, Gitea, Forgejo, Bitbucket) with different PR/MR models.
 
 ## Shipped
+
+### W2: Bulk branch cleanup (`gitbox sweep`)
+
+- **Status:** shipped
+- **Shipped:** 2026-04-09
+- **Priority:** P1
+- **Size:** M
+- **Concept:** Safely delete local branches that have been merged upstream or removed on the remote, across all repos in a source or across all sources. A `gitbox sweep` CLI command plus a TUI action and GUI panel.
+- **Notes:** Implemented with `StaleBranches`/`DeleteBranch` git helpers, CLI `sweep` command with `--source`/`--repo`/`--dry-run` flags, TUI `s` keybinding, and GUI "Sweep branches" in kebab menu. Includes squash-merge detection via cherry/patch-id comparison.
 
 ### W6: Open in browser
 

--- a/.claude/skills/wish/SKILL.md
+++ b/.claude/skills/wish/SKILL.md
@@ -11,6 +11,7 @@ description: Manage the gitbox feature radar — view priorities, capture new id
 
 ```text
 /wish                  Show the radar overview
+/wish help             Show available commands
 /wish list             One-line summary of all pending wishes
 /wish add <title>      Capture a new feature idea
 /wish plan <id>        Deep-dive and create implementation plan
@@ -21,6 +22,10 @@ description: Manage the gitbox feature radar — view priorities, capture new id
 ## Data file
 
 The single source of truth is `.claude/context/feature-radar.md`. Always re-read it at execution time — it may have been edited manually.
+
+## `/wish help` — Show available commands
+
+Print the usage block from the Usage section above, verbatim. No file reads, no radar parsing — just the command reference.
 
 ## `/wish` (no arguments) — Radar overview
 

--- a/cmd/cli/pull_cmd.go
+++ b/cmd/cli/pull_cmd.go
@@ -63,7 +63,11 @@ var pullCmd = &cobra.Command{
 				rs := status.Check(dest)
 				if rs.State == status.Clean || rs.State == status.Ahead || rs.State == status.NoUpstream {
 					if verbose {
-						printStatusLine("~", "skip", label, rs.State.String(), colorCyan)
+						reason := rs.State.String()
+						if rs.State == status.NoUpstream && rs.Branch != "" {
+							reason = fmt.Sprintf("local branch [%s]", rs.Branch)
+						}
+						printStatusLine("~", "skip", label, reason, colorCyan)
 					}
 					skipped++
 					continue

--- a/cmd/cli/status_cmd.go
+++ b/cmd/cli/status_cmd.go
@@ -204,17 +204,25 @@ func printRepoStatus(cfg *config.Config) {
 		symbol, color := stateToSymbolColor(r.State)
 		details := formatDetails(r)
 
+		// Branch badge: show when not on the default branch.
+		repoLabel := r.Repo
+		if r.Branch == "(detached)" {
+			repoLabel += colorize(" [detached]", colorRed)
+		} else if r.Branch != "" && !r.IsDefault {
+			repoLabel += colorize(" ["+r.Branch+"]", colorCyan)
+		}
+
 		// Show symbol + state label + repo + details.
 		stateLabel := r.State.String()
 		if details != "" {
 			fmt.Printf("    %s  %-50s  %s\n",
 				colorize(fmt.Sprintf("%s %-10s", symbol, stateLabel), color),
-				r.Repo,
+				repoLabel,
 				details)
 		} else {
 			fmt.Printf("    %s  %s\n",
 				colorize(fmt.Sprintf("%s %-10s", symbol, stateLabel), color),
-				r.Repo)
+				repoLabel)
 		}
 	}
 	fmt.Println()
@@ -270,7 +278,10 @@ func formatDetails(r status.RepoStatus) string {
 	case status.NotCloned:
 		return "not cloned"
 	case status.NoUpstream:
-		return "no upstream"
+		if r.IsDefault {
+			return "no upstream"
+		}
+		return "local branch"
 	case status.Error:
 		return r.ErrorMsg
 	default:

--- a/cmd/cli/tui/dashboard.go
+++ b/cmd/cli/tui/dashboard.go
@@ -374,6 +374,12 @@ func computeAccountStats(statuses []status.RepoStatus, cfg *config.Config) map[s
 			s.behind++
 		case status.NotCloned:
 			s.notCloned++
+		case status.NoUpstream:
+			if r.IsDefault {
+				s.other++ // No upstream on default branch is a real issue.
+			} else {
+				s.clean++ // Feature branch with no upstream is normal.
+			}
 		default:
 			s.other++
 		}
@@ -868,11 +874,20 @@ func (m dashboardModel) viewRepoList() string {
 			}
 		}
 
+		// Branch badge: show when not on the default branch.
+		var branchTag string
+		if r.Branch == "(detached)" {
+			branchTag = " " + lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.Palette.StatusError)).Render("[detached]")
+		} else if r.Branch != "" && !r.IsDefault {
+			branchTag = " " + m.theme.TextMuted.Render("["+r.Branch+"]")
+		}
+
 		symStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
-		line := fmt.Sprintf("    %s %-10s  %-25s  %s%s",
+		line := fmt.Sprintf("    %s %-10s  %-25s%s  %s%s",
 			symStyle.Render(sym),
 			symStyle.Render(stateLabel),
 			r.Repo,
+			branchTag,
 			m.theme.TextMuted.Render(detail),
 			inlineProgress)
 
@@ -1362,6 +1377,11 @@ func formatStatusDetail(r status.RepoStatus) string {
 		return strings.Join(parts, ", ")
 	case status.Conflict:
 		return fmt.Sprintf("%d conflicts", r.Conflicts)
+	case status.NoUpstream:
+		if r.IsDefault {
+			return "no upstream"
+		}
+		return "local branch"
 	case status.Error:
 		return r.ErrorMsg
 	default:

--- a/cmd/cli/tui/screen_repos.go
+++ b/cmd/cli/tui/screen_repos.go
@@ -409,7 +409,10 @@ func (m reposModel) View() string {
 	b.WriteString(fmt.Sprintf("  %-15s %s\n", m.theme.TextMuted.Render("Source:"), m.theme.Text.Render(m.sourceKey)))
 	b.WriteString(fmt.Sprintf("  %-15s %s\n", m.theme.TextMuted.Render("Path:"), m.theme.Text.Render(m.repoPath())))
 
-	if m.branch != "" {
+	if m.branch == "(detached)" {
+		b.WriteString(fmt.Sprintf("  %-15s %s\n", m.theme.TextMuted.Render("Branch:"),
+			lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.Palette.StatusError)).Render("HEAD detached")))
+	} else if m.branch != "" {
 		b.WriteString(fmt.Sprintf("  %-15s %s\n", m.theme.TextMuted.Render("Branch:"), m.theme.Text.Render(m.branch)))
 	}
 	if m.ahead > 0 || m.behind > 0 {

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -820,6 +820,8 @@ type StatusResult struct {
 	Untracked int  `json:"untracked"`
 	Conflicts int  `json:"conflicts"`
 	Error    string `json:"error,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	IsDefault bool   `json:"isDefault,omitempty"`
 }
 
 func toStatusResult(rs status.RepoStatus) StatusResult {
@@ -835,6 +837,8 @@ func toStatusResult(rs status.RepoStatus) StatusResult {
 		Untracked: rs.Untracked,
 		Conflicts: rs.Conflicts,
 		Error:    rs.ErrorMsg,
+		Branch:   rs.Branch,
+		IsDefault: rs.IsDefault,
 	}
 }
 

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1597,6 +1597,11 @@
             <div class="compact-row" class:compact-row-ok={state.status === 'clean'}>
               <span class="compact-dot" style="color: {sc(state.status)}">{statusSymbol(state.status)}</span>
               <span class="compact-repo-name">{repoName.includes('/') ? repoName.split('/').pop() : repoName}</span>
+              {#if state.branch === '(detached)'}
+                <span class="compact-badge" style="color: {sc('error')}">detached</span>
+              {:else if state.branch && !state.isDefault}
+                <span class="compact-badge branch-badge">{state.branch}</span>
+              {/if}
               {#if state.status === 'behind'}
                 <span class="compact-badge" style="color: {sc('behind')}">{state.behind} behind</span>
               {:else if state.status === 'dirty'}
@@ -1853,6 +1858,11 @@
             {/if}
             <span class="dot" style="color: {sc(state.status)}">{statusSymbol(state.status)}</span>
             <span class="repo-name">{repoName}</span>
+            {#if state.branch === '(detached)'}
+              <span class="branch-badge detached">detached</span>
+            {:else if state.branch && !state.isDefault}
+              <span class="branch-badge">{state.branch}</span>
+            {/if}
 
             {#if state.status === 'syncing' || state.status === 'cloning'}
               <div class="progress-track">
@@ -1866,7 +1876,11 @@
                 {:else if state.status === 'not cloned'}
                   <span class="status-text" style="color:{sc('not cloned')}">Not local</span>
                 {:else if state.status === 'no upstream'}
-                  <span class="status-text" style="color:{sc('no upstream')}">No upstream</span>
+                  {#if state.isDefault}
+                    <span class="status-text" style="color:{sc('no upstream')}">No upstream</span>
+                  {:else}
+                    <span class="status-text" style="color:{sc('clean')}">Local branch</span>
+                  {/if}
                 {:else if state.status === 'error'}
                   <span class="status-text" style="color:{sc('error')}">Error</span>
                 {:else}
@@ -3164,6 +3178,8 @@
   .status-badges { display: flex; align-items: center; gap: 6px; }
   .sbadge { font-size: 11px; font-weight: 600; white-space: nowrap; }
   .status-pending { font-size: 12px; font-weight: 600; color: var(--text-dim); }
+  .branch-badge { font-size: 10px; padding: 1px 5px; border-radius: 3px; background: var(--bg-hover); color: var(--text-dim); white-space: nowrap; }
+  .branch-badge.detached { color: var(--status-error, #D81E5B); }
 
   /* ── Repo detail panel ── */
   .repo-row-clickable { cursor: pointer; }

--- a/cmd/gui/frontend/src/lib/stores.ts
+++ b/cmd/gui/frontend/src/lib/stores.ts
@@ -51,6 +51,8 @@ export function applyStatusResults(results: StatusResult[]) {
           untracked: r.untracked,
           ahead: r.ahead,
           error: r.error,
+          branch: r.branch,
+          isDefault: r.isDefault,
         };
       }
     }
@@ -87,6 +89,7 @@ export const accountStats = derived([sources, repoStates], ([$src, $rs]) => {
       if (!state) continue;
       stats[acctKey].total++;
       if (state.status === 'clean') stats[acctKey].synced++;
+      else if (state.status === 'no upstream' && !state.isDefault) stats[acctKey].synced++;
       else stats[acctKey].issues++;
     }
   }

--- a/cmd/gui/frontend/src/lib/types.ts
+++ b/cmd/gui/frontend/src/lib/types.ts
@@ -108,6 +108,8 @@ export interface StatusResult {
   untracked: number;
   conflicts: number;
   error?: string;
+  branch?: string;
+  isDefault?: boolean;
 }
 
 export interface DiscoverResult {
@@ -133,6 +135,8 @@ export interface RepoState {
   untracked: number;
   ahead: number;
   error?: string;
+  branch?: string;
+  isDefault?: boolean;
 }
 
 export interface EditorInfo {

--- a/cmd/gui/frontend/wailsjs/go/models.ts
+++ b/cmd/gui/frontend/wailsjs/go/models.ts
@@ -567,6 +567,8 @@ export namespace main {
 	    untracked: number;
 	    conflicts: number;
 	    error?: string;
+	    branch?: string;
+	    isDefault?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new StatusResult(source);
@@ -585,6 +587,8 @@ export namespace main {
 	        this.untracked = source["untracked"];
 	        this.conflicts = source["conflicts"];
 	        this.error = source["error"];
+	        this.branch = source["branch"];
+	        this.isDefault = source["isDefault"];
 	    }
 	}
 	export class SweepDeleteDTO {

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -195,7 +195,7 @@ gitbox clone --verbose              # Show all repos including skipped
 gitbox status
 ```
 
-Shows config info, account credential health, and per-repo sync state grouped by source.
+Shows config info, account credential health, and per-repo sync state grouped by source. Repos on a non-default branch display a `[branch-name]` badge. Feature branches with no upstream show "local branch" instead of the generic "no upstream."
 
 ### Pull updates
 
@@ -203,7 +203,7 @@ Shows config info, account credential health, and per-repo sync state grouped by
 gitbox pull
 ```
 
-Pulls repos that are behind (fast-forward only). Dirty or conflicted repos are skipped with a warning.
+Pulls repos that are behind (fast-forward only). Dirty or conflicted repos are skipped with a warning. Repos on local branches with no upstream are skipped — use `--verbose` to see which repos were skipped and why.
 
 ```bash
 gitbox pull --verbose    # Show all repos including clean ones

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -102,6 +102,10 @@ Gitbox watches your projects and shows their status:
 - **Local changes** (orange) — you have uncommitted work
 - **Ahead** (blue) — you have commits that haven't been pushed
 - **Not local** (grey) — the repo hasn't been cloned yet
+- **Local branch** (green) — on a feature branch with no upstream tracking (normal)
+- **No upstream** (grey) — default branch has no upstream tracking (needs attention)
+
+When a repo is checked out on a non-default branch, a small branch badge appears next to the repo name (e.g., `feature-xyz`). Repos on the default branch show no badge. Detached HEAD state shows a red `detached` badge.
 
 #### Pull All
 

--- a/docs/radar-meeting-ai.md
+++ b/docs/radar-meeting-ai.md
@@ -1,0 +1,46 @@
+# Concepto de AI Box - AI summary
+
+- Aplicación de escritorio nativa (Windows, Mac, Linux) para gestionar proyectos con IA
+- Integra múltiples herramientas: Git, Obsidian, Claude Code, Gemini CLI, Cursor
+- Funciona como “caparazón” o wrapper que une diferentes mundos tecnológicos
+- No es un LLM ni reemplaza herramientas existentes, sino que las conecta
+
+### Funcionalidades Core
+
+- Gestión jerárquica de carpetas de proyectos
+  - Organización por mercados, tipos, clientes
+  - Cada carpeta final = repositorio Git clonado
+- Creación de proyectos nuevos con plantillas
+  - Descripción del proyecto y título
+  - Selección de cuenta Git para versionado
+  - Elección de arnés de IA (inicialmente Claude Code)
+  - Knowledge base integration
+- Detección automática de herramientas instaladas
+- Botones de acceso directo: VS Code, Claude Code (terminal nativo), Obsidian
+
+### Sistema de Plantillas
+
+- Plantillas sectorizadas por mercados (ej: clínicas veterinarias)
+- Estructura automática de carpetas adecuada por tipo de proyecto
+- Base inicial de Obsidian preconfigurada
+- Skills predefinidos (máximo 10-12):
+  - Pre-meeting preparation
+  - Post-meeting resume
+  - Transcripción processing
+  - Estructura de reuniones con tópicos y fechas
+
+### Gestión Multi-Harness
+
+- Soporte futuro para múltiples arneses de IA
+- Migración transparente entre herramientas (Claude → Codex → Gemini)
+- Personalización de directorios por proyecto
+- Integración con proyecto open source existente para multi-harness por línea de comandos
+
+### Casos de Uso Identificados
+
+- Desarrolladores principiantes que acumulan muchos proyectos
+- Gestión de conversaciones con clientes potenciales
+  - Transcripción automática de reuniones
+  - Embedding de cambios de requisitos en proyectos existentes
+- Trabajo repetitivo automatizado en flujos cliente-consultor
+- Organización centralizada de proyectos con IA

--- a/docs/radar-meeting-raw.md
+++ b/docs/radar-meeting-raw.md
@@ -1,0 +1,81 @@
+# Concepto de AI Box - Transcript
+
+Date: Apr 9
+
+Transcript:
+ 
+Them: No se me ocurren qué funcionalidades se podrían implementar en esta herramienta, ¿sabes?, eso tendría que dar una vuelta.  
+Me: Lo que a mí me gustaría tener es una aplica  
+Them: O sea, lo tendría que utilizar para ver qué echa en falta.  
+Me: Vale.  
+Them: ¿Sabes?  
+Me: A mí lo que me gustaría tener es una aplicación de escritorio nativa que funcione en Win Mac, o Linux, que me que me permita gestionar todas las carpetas donde tengo mis proyectos, que son todos proyectos donde tengo instalado habilitado el trabajar con un harness, con un arnés, de inteligencia artificial, como Claude, Code o como Gemini CLI o como Codex o cualquiera de estos? La idea es que esa se, que cada carpeta sea un proyecto, que pueda estar estructurado de alguna forma lógica, por por mercados, por tipo de proyectos, por clientes, por lo que sea, que son como un gestor del conocimiento que tengo de mi de mis propios proyectos. Que esa aplicación sea capaz, no solamente de ofrecerme una estructura jerárquica bien organizada y profesional, sino que, además, eso esté perfectamente ligado a las estructuras de de carpetas que debería tener cuando cada uno de esos folders o carpetas finales son a la vez un un clon de un repositorio en un servidor Git. Que la aplicación mía, que la podemos llamar la caja de inteligencia artificial, nuestra caja de inteligencia artificial enseña las carpetas, que las carpetas finales, las las el el folder final sea el inicio de un repositorio que en Git, que me haga la gestión de esos clones, que me permita crear repositorios y clonarlos, que me permita tener una visibilidad de cómo de, si están actualizados o si están desactualizados, que no me haga ninguna de la gestión de las ramas de de subir a Git, de modificar, de hacer fusiones, todo no, eso lo tiene que hacer la persona en otro tipo de herramientas. Esto es como un caparazón que me, o interfaz, o marco en el que yo veo todos mis proyectos, y la herramienta me ayuda a hacer una gestión muy como, por ejemplo, quiero crear un proyecto nuevo que me permita que él sepa si está Claude instalado, si está Obsidian instalado, y que me diga, ¿quieres instalar un proyecto estándar una plantilla para que Obsidian y Claude se te conecte? Utilizando la nueva modalidad de conexión Sí, no, etcétera. Y eso me gustaría hacerlo partiendo de Gitbox.  
+Them: The AI box.  
+Me: ¿A ti qué? Sí, partiendo de un proyecto anterior, que ahora mismo lo que está haciendo es  
+Them: Ah, vale.  
+Me: gestión de clonex Git, pero partiendo de esa idea, enriquecerlo para sea una herramienta que sirva a la gente que está empezando a trabajar con muchos proyectos, siempre, utilizando un LLM, perdón, un arnés de IA, como puedo hacer Cloud Code.  
+Them: Un un arnés  
+Me: Que esa gente les ayude.  
+Them: para agentes, un agent arnés.  
+Me: Exacto. Entonces, ¿qué funcionalidades se te ocurren a ti  
+Them: Harness.  
+Me: que podrían estar bien que tuviese eso? ¿Qué necesitarías tú? Que tú trabajas con muchos?  
+Them: Claro, vale, es que, a ver, si yo estoy  
+Me: Proyectos?  
+Them: entendiendo bien lo que o sea, como yo me lo imaginaría en su mejor versión, es dependiendo del tipo de proyecto que vas a hacer, la el box de inteligencia artificial te cree la estructura de carpetas adecuada a ese tipo de proyecto.  
+Me: Perfecto, Perfecto, eso es una funcionalidad.  
+Them: Eso es un eso es como yo veo, vería la versión  
+Me: Perfecto.  
+Them: final, porque porque eso tiene millones de funcionalidades dentro, ¿sabes?  
+Me: Vale. Pero yendo por partes, una de las funcionalidades que tú ves que te podría ayudar más es que cuando tú arrancas tu tu caja de de proyectos IA,  
+Them: Sí, bueno, estoy pensando en en lo que le ayudaría al público  
+Me: al público en general. Es una opción más,  
+Them: o sea,  
+Me: le das ese más, te pregunta el proyecto, te permite elegir entre le describes el título del proyecto, una pequeña descripción, nada más. Le puedes poner con qué cuenta de Git quieres trabajar, porque quieres tener, lo quieres versionar, perdón, lo quieres versionar y quieres hacer copias de seguridad y lo vas a hacer con Git, con qué arnés vas a trabajar y te ofrecerá, inicialmente, solo Cloud Code, pero en el futuro otras, y con qué knowledge base quieres trabajar te ofrecerá. Y luego, con esa información, no tienes suficiente, necesitaría tener una lista tendríamos que ofrecer una lista de plantillas de tipo de proyecto. Empezaríamos con dos o tres, pero en el futuro esas plantillas podrían estar por mercados sectorizadas. Por ejemplo, quiero crear un project para clínicas veterinarias. Vale, pues salud animal, clínicas. Y, automáticamente, que construye la que debería ser la estructura adecuada, debería crear una pequeña base inicial con Obsidian, debería eso conectado ya con la configuración en el m server de de Claude, y tal. Y lo que tú ves en pantalla no es más que una carpeta con un nombre, Si te pones por encima, ves proyecto veterinarias, y con dos botones, un botón para abrir VSECODE y empezar a el Visual Studio Code y empezar a trabajar con él, otro botón para abrir Cloud Code directamente en una sesión nativa en un terminal, otro botón para abrirte Obsidian, y abras lo que abras, ya ahí en la aplicación deja de tener el control. Es simplemente un un caparazón para facilitar la estructura inicial. Tú puedes estar trabajando en tus herramientas nativas en ese proyecto, y cuando te sales, tu aplicación detecta si has hecho copia de seguridad has hecho un Git push o no, si está actualizado. Si necesitas tener más no lo sé, algún otro tipo de gestión de estados, que puedas borrar proyectos, que puedas mover que puedas renombrar proyectos, y que todo eso sea compatible con la estructura de directorios, que sea compatible con Git, que sea compatible con Claude, etcétera, etcétera, etcétera. No es un LLM, no es un Obsidian, no es Git, pero es algo que une todo el mundo y es como un caparazón que une todos esos mundos para facilitar el uso a los a las personas.  
+Them: Sí, esta vez, sí, sí, sí. Vale. O sea, a mí lo que me parece muy buena es que cada vez va a haber más gente que empieza a desarrollar, como yo, por ejemplo, pero gente como yo que no tiene ni idea. Entonces, ¿qué pasa? Que le lo que les va a pasar es eso, que van a hacer un huevo de proyectos y cada vez más, y pasarán los años y millones de proyectos, entonces, lo que estaría guay es como tener un sitio donde tienes todo eso bien organizado.  
+Me: Gestión, gestión de proyectos hechos  
+Them: Sí, por, sí, bueno, todo el mundo, sí,  
+Me: con IA. Y  
+Them: ponía.  
+Me: Exacto, porque es un IA Box,  
+Them: Exacto.  
+Me: o hay que buscarle un nombre, hay que buscarle un nombre porque es no existe, es como un  
+Them: AI management.  
+Me: Sí, no, sí, o project manage, esto es al final project management, pero super super gestor de proyectos, es un gestor de proyectos hechos con IA. Y, entonces, es un facilitador para la gestión, la sincronización, la gestión de versiones, el mantenimiento, la estructura de directorios y plantillas. Y es eso. Es  
+Them: Thanks.  
+Me: es eso.  
+Them: Exacto, o sea, centrarlo en en algo concreto para no sobre desarrollar funcionalidades  
+Me: Certo.  
+Them: que sean necesarias.  
+Me: Lo que hay que hacer es hacerlo de tal forma que se le puedan añadir diferentes herramientas en el futuro. Que empiece con Git, con Obsidian y Cloud Code. Porque hay que empezar por algo, pero que en el futuro te quieres cambiar a Gemini,  
+Them: Ya está. Sí.  
+Me: Pues, que lo puedes añadir, que en el futuro te puedes, te quieres crear utilizar Codecs, que lo puedas añadir, que tienes un que tienes una licencia con Cloud Code y uno de tus proyectos o o cien proyectos tuyos están con Cloud Code, y que abandonas esa licencia y te pasas a Codex, que te migre todos los ficheros de Claude, a formato Codex, y que te lo haga transparente, que tienes dos licencias que te personalice los directorios de debajo de cada proyecto para que te pueda aprovechar Porque unas veces abres desde Codex y otras veces, a lo mejor, lo  
+Them: Oh, curso, lo... Sí.  
+Me: desde Gemini CLI, o Cursor. Da igual que el proyecto  
+Them: Lo entiendo.  
+Me: sea capaz de hacerte toda la gestión  
+Them: Harness.  
+Me: exacto. Vale, de hecho,  
+Them: Multiarness,  
+Me: como referencia, que no se nos olvide buscar, porque ya hay un por ahí, open source, que es capaz de hacerte eso, pero por línea de comandos. Es capaz de hacerte un mantenimiento nativo de tu proyecto para que trabaje en multi-harness.  
+Them: Vale.  
+Me: Entonces, sería coger esas ideas o, incluso, ese proyecto e integrarlo dentro de nuestra Nuestra caja va a ser un wrapper, que no sé bien cómo se traduce, wrapper.  
+Them: Un envoltorio, una envoltura,  
+Me: Un envoltorio, una envoltura, exacto.  
+Them: Sí.  
+Me: Que sea una envoltura para gestión de proyectos y facilitar su trabajo con ellos y, sobre todo, facilitar crearte uno nuevo. Tú tienes vas a abrir una conversación con un cliente potencial nuevo pues, a lo mejor grabas la conversación o la transcribes con la IA te creas el proyecto, te vas a la herramienta, crear proyecto nuevo, le das la descripción, el check te hace una plantilla, le das que sí, y te deja preparado el documento donde debes de tener las primeras reuniones, una estructura de carpetas de reuniones, que esas reuniones tengan el tópico, la fecha, no sé qué, que tenga los skills ya hechos, luego tú lo único que tienes que hacer es copiar y pegar la transcripción, y que, automáticamente, el skill ya te deje todo lo demás preparado.  
+Them: Sí, eso eso no lo haría. Exacto. Exacto, eso es muy útil porque eso es algo justo es  
+Me: Es trabajo repetitivo que se lo ahorras.  
+Them: justo esta mañana lo pensaba, que estaría guapa una aplicación, porque que ahora va a empezar a ser y cada vez más útil, que, por ejemplo, que a mí me está pasando, que tú tienes una reunión con un cliente y te dice, ah, pero esto no lo quiero así, esto no lo quiero hasta Ah, pero esto tal, x, y, z, y te empieza a decir un montón de cosas. Entonces, que, de alguna forma, la aplicación, no sé si esta o otra, te coja esa transcripción y que te lo enbeba en el proyecto que ya está, que el o el que sea, para la nuevas que te ha pedido y en las secciones en las que te los ha pedido.  
+Me: Esatto. Exacto, exacto, exacto. Pues estaría bien  
+Them: ¿Sabes? Pero no sé si AI Box es para esto.  
+Me: porque al, No lo, no, pero AI Box  
+Them: O es una aplicación diferente.  
+Me: lo que te, yo creo que eso es las plantillas. Si las plantillas te facilitan la vida, las plantillas tienen que ser lo suficientemente potentes, a la vez que sencillas y que te den flexibilidad, es decir, que yo voy a tener un proyecto, y es que hay cosas que siempre repetimos los humanos. Que es, voy a hablar con los clientes, voy a tener reuniones, necesito saber qué pasa en esa reunión, cuáles son las ideas que salen de ahí, cuáles son los siguientes pasos, cómo preparan la siguiente reunión, y de todo eso, pues hay que hacer un un posible plan de negocio de propuesta a ese cliente, después de la propuesta hay que hacer un discovery, después hay que hacer pues, todo el flujo de trabajo con los clientes por sector, por tal y todo el cual, siempre son los mismos. ¿Cómo podemos eso para que yo arranque la aplicación, le digo a proyecto nuevo, y, me lo ponga todo. Y, entonces, yo luego ya me voy a las herramientas que yo tenga contratadas, a a Cloud Code, etcétera, y ya empiezo a trabajar en el proyecto, pero ya tengo hechos los skills, ya tengo ya sé dónde tiene que ir cada cosa, ya tengo el skill de preparameeting, post meeting, resume transcripción, ya los tengo hecho, y tampoco hay que hacer quinientos skills. Yo diría, máximo, diez, doce, pero que sean muy, muy, muy, muy, muy, muy útiles, y que también tengas tal. Y luego, otra cosa es cómo prepararte la estructura de Obsidian. Por proyecto, para que lo puedas hacer por proyecto. O, a lo mejor, la, a lo mejor, descubrimos Obsidian hay que tenerlo a nivel global, y debe tener visibilidad de todo, o no,  
+Them: Claro.  
+Me: No lo sé, es que depende, es que eso hay que ir descubriendo. Entonces, la aplicación tiene que ir siendo cada vez más capaz de hacer eso. Bueno,  
+Them: It's eighth up.  
+Me: voy a transcribir esto.  
+Them: Pásamelo.  
+Me: Vale, chao.  
+Them: Venga, chau chau. 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -243,6 +243,10 @@ Status indicators:
 | `~`    | Orange | no upstream | No tracking branch      |
 | `x`    | Red    | error       | Git error               |
 
+When a repo is checked out on a non-default branch, a `[branch-name]` badge appears after the repo name. Repos on the default branch show no badge. If a repo is on a local branch with no upstream tracking, the detail shows "local branch" instead of "no upstream" — this is normal for feature branches and is not counted as an issue in account summaries.
+
+The `--json` output includes `branch` (current branch name) and `is_default` (boolean) fields for each repo.
+
 ---
 
 ## Cloning

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -89,6 +89,8 @@ type RepoStatus struct {
 	Untracked int  `json:"untracked,omitempty"`
 	Conflicts int  `json:"conflicts,omitempty"`
 	ErrorMsg string `json:"error,omitempty"`
+	Branch    string `json:"branch,omitempty"`     // Current branch name (or "(detached)")
+	IsDefault bool   `json:"is_default,omitempty"` // True when current branch is the repo's default branch
 }
 
 // Check determines the sync status of a single repo at the given path.
@@ -112,6 +114,14 @@ func Check(repoPath string) RepoStatus {
 	rs.Modified = st.Modified
 	rs.Untracked = st.Untracked
 	rs.Conflicts = st.Conflicts
+	rs.Branch = st.Branch
+
+	// Determine if current branch is the default.
+	if st.Branch != "" && st.Branch != "(detached)" {
+		if def, err := git.DefaultBranch(repoPath); err == nil {
+			rs.IsDefault = st.Branch == def
+		}
+	}
 
 	// Determine state.
 	switch {

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -52,6 +52,55 @@ func TestCheckClean(t *testing.T) {
 	}
 }
 
+func TestCheck_BranchPopulated(t *testing.T) {
+	clone, _ := initTestRepo(t)
+	rs := Check(clone)
+	if rs.Branch == "" {
+		t.Error("expected Branch to be populated")
+	}
+	// initTestRepo creates a repo with master as default.
+	if rs.Branch != "master" {
+		t.Errorf("branch = %q, want %q", rs.Branch, "master")
+	}
+}
+
+func TestCheck_IsDefault(t *testing.T) {
+	clone, _ := initTestRepo(t)
+	rs := Check(clone)
+	if !rs.IsDefault {
+		t.Error("expected IsDefault = true for default branch")
+	}
+}
+
+func TestCheck_FeatureBranch(t *testing.T) {
+	clone, _ := initTestRepo(t)
+	runGit(t, clone, "checkout", "-b", "feature-xyz")
+	rs := Check(clone)
+	if rs.Branch != "feature-xyz" {
+		t.Errorf("branch = %q, want %q", rs.Branch, "feature-xyz")
+	}
+	if rs.IsDefault {
+		t.Error("expected IsDefault = false for feature branch")
+	}
+	// Local branch with no upstream → NoUpstream state.
+	if rs.State != NoUpstream {
+		t.Errorf("state = %v, want NoUpstream", rs.State)
+	}
+}
+
+func TestCheck_DetachedHead(t *testing.T) {
+	clone, _ := initTestRepo(t)
+	// Detach HEAD at the current commit.
+	runGit(t, clone, "checkout", "--detach", "HEAD")
+	rs := Check(clone)
+	if rs.Branch != "(detached)" {
+		t.Errorf("branch = %q, want %q", rs.Branch, "(detached)")
+	}
+	if rs.IsDefault {
+		t.Error("expected IsDefault = false for detached HEAD")
+	}
+}
+
 func TestCheckDirty(t *testing.T) {
 	clone, _ := initTestRepo(t)
 	writeFile(t, filepath.Join(clone, "README.md"), "# changed\n")


### PR DESCRIPTION
## Summary

- Add `Branch` and `IsDefault` fields to `status.RepoStatus`, populated from existing `git.Status().Branch` and `git.DefaultBranch()` — flows through the entire status pipeline to all three UIs
- Show a `[branch-name]` badge in dashboard rows (TUI, GUI, CLI) when the repo is on a non-default branch; no badge when on the expected default branch
- Soften "No upstream" to "Local branch" when on a feature branch (normal workflow), keep "No upstream" as a warning only when the default branch has no tracking
- Handle detached HEAD explicitly — shows red `[detached]` / `HEAD detached` badge
- Fix account card stats: feature branches with no upstream no longer inflate the issue count
- Improve `gitbox pull --verbose` skip reporting: shows `local branch [feature-x]` instead of generic "no upstream"

Closes W7 on the feature radar.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -short ./...` all pass (4 new status tests: branch populated, isDefault, feature branch, detached HEAD)
- [x] CLI build succeeds
- [x] GUI build succeeds (Wails)
- [ ] Manual: checkout a feature branch in a managed repo → verify badge appears in TUI, GUI, and `gitbox status`
- [ ] Manual: checkout main → verify no badge
- [ ] Manual: detach HEAD → verify red detached indicator
- [ ] Manual: run `gitbox pull -v` with a local-only branch → verify "local branch [name]" in skip message
- [ ] Manual: verify account card no longer shows "attention" for repos on feature branches