### PR TITLE
Fix spurious update banner on dev builds

### DIFF
--- a/cmd/cli/update_cmd.go
+++ b/cmd/cli/update_cmd.go
@@ -31,7 +31,7 @@ func init() {
 func updateOpts() update.Options {
 	cacheDir := filepath.Join(config.ConfigRoot(), config.V2ConfigDir)
 	return update.Options{
-		CurrentVersion: version,
+		CurrentVersion: update.ResolveVersion(version),
 		Repo:           "LuisPalacios/gitbox",
 		CacheFile:      filepath.Join(cacheDir, ".update-check"),
 		ThrottleDur:    24 * time.Hour,

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -158,7 +158,7 @@ type UpdateInfo struct {
 func (a *App) updateOpts() update.Options {
 	cacheDir := filepath.Join(config.ConfigRoot(), config.V2ConfigDir)
 	return update.Options{
-		CurrentVersion: version,
+		CurrentVersion: update.ResolveVersion(version),
 		Repo:           "LuisPalacios/gitbox",
 		CacheFile:      filepath.Join(cacheDir, ".update-check"),
 		ThrottleDur:    24 * time.Hour,

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -130,15 +130,14 @@ func checkLatestAPI(ctx context.Context, opts Options) (*CheckResult, error) {
 		return nil, fmt.Errorf("parsing release JSON: %w", err)
 	}
 
-	// Parse current version — if it's "dev" or unparseable, treat as "always behind".
+	// Compare versions. If the current version is unparseable (a dev build
+	// where git describe failed, a shallow clone, or any other tagless
+	// state), hide the banner rather than nag with a false positive — the
+	// user can force a check with `gitbox update --check` if they actually
+	// want to know.
 	newer, err := IsNewer(opts.CurrentVersion, release.TagName)
 	if err != nil {
-		// Dev builds can't compare — always report as available.
-		if strings.Contains(opts.CurrentVersion, "dev") {
-			newer = true
-		} else {
-			return nil, fmt.Errorf("comparing versions: %w", err)
-		}
+		newer = false
 	}
 
 	return &CheckResult{

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -62,6 +63,12 @@ func TestIsNewer(t *testing.T) {
 		{"v1.0.1", "v1.0.0", false},
 		{"v1.0.0", "v1.0.0", false},
 		{"v2.0.0", "v1.9.9", false},
+		// Dev builds: ParseVersion strips the "-N-gSHA-dev" suffix, so the
+		// comparison is against the base tag. A dev build ahead of the tag
+		// is NOT newer than the tag; a dev build behind the tag IS.
+		{"v1.3.0-3-gabcdef-dev", "v1.3.0", false},
+		{"v1.2.9-3-gabcdef-dev", "v1.3.0", true},
+		{"v1.3.0-dev", "v1.3.0", false},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +82,35 @@ func TestIsNewer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveVersion(t *testing.T) {
+	// Production / ldflags-set versions pass through unchanged.
+	passthrough := []string{"v1.2.3", "v1.2.3-dev", "v0.0.1", "custom"}
+	for _, v := range passthrough {
+		t.Run("passthrough/"+v, func(t *testing.T) {
+			if got := ResolveVersion(v); got != v {
+				t.Errorf("ResolveVersion(%q) = %q, want %q", v, got, v)
+			}
+		})
+	}
+
+	// The "dev" placeholder triggers a git describe lookup. When the test
+	// runs from inside the gitbox repo (the normal case), the result must
+	// contain "-dev" and parse to a valid semver. When it can't reach git
+	// (e.g. GIT_DIR pointed at a non-repo), it falls back to "dev".
+	t.Run("dev/git-describe", func(t *testing.T) {
+		got := ResolveVersion("dev")
+		if got == "dev" {
+			t.Skip("git describe unavailable in this environment")
+		}
+		if !strings.HasSuffix(got, "-dev") {
+			t.Errorf("ResolveVersion(\"dev\") = %q, expected a *-dev suffix", got)
+		}
+		if _, err := ParseVersion(got); err != nil {
+			t.Errorf("ResolveVersion(\"dev\") = %q, not a parseable semver: %v", got, err)
+		}
+	})
 }
 
 // ── Check tests ──

--- a/pkg/update/version.go
+++ b/pkg/update/version.go
@@ -1,0 +1,35 @@
+package update
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/LuisPalacios/gitbox/pkg/git"
+)
+
+// ResolveVersion returns the version string suitable for comparing against
+// release tags. For ldflags-set production builds (anything other than the
+// literal "dev") it returns the input unchanged. For dev builds it shells
+// out to `git describe --tags --always` and appends "-dev" to the output,
+// so a build three commits past v1.3.0 becomes "v1.3.0-3-gabcdef-dev" —
+// which ParseVersion strips back to 1.3.0 for semantic comparison.
+// Returns "dev" unchanged if git describe fails (shallow clone, no tags,
+// not run from inside a repo) so that callers can hide the update banner
+// rather than nag with a false positive.
+func ResolveVersion(rawVersion string) string {
+	if rawVersion != "dev" {
+		return rawVersion
+	}
+	cmd := exec.Command(git.GitBin(), "describe", "--tags", "--always")
+	cmd.Env = git.Environ()
+	git.HideWindow(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "dev"
+	}
+	tag := strings.TrimSpace(string(out))
+	if tag == "" {
+		return "dev"
+	}
+	return tag + "-dev"
+}


### PR DESCRIPTION
Closes #34.

## Summary

- New `pkg/update/ResolveVersion(raw)` helper that turns the literal `"dev"` ldflags placeholder into the real git-described version (`v1.3.0-3-gabcdef-dev`), while passing CI-stamped versions through unchanged.
- Both `cmd/gui/updateOpts()` and `cmd/cli/updateOpts()` now feed the update check with the resolved version, so dev builds compare correctly against release tags instead of being reported as `"dev"` and triggering the dev-fallback.
- `pkg/update/check.go` replaces the old `strings.Contains(version, "dev") → newer=true` branch with a silent `newer=false` when `ParseVersion` fails. An unidentifiable build should not nag with a false positive; the user can force an explicit check with `gitbox update --check` if they actually want to know.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./pkg/update/` — new `TestResolveVersion` and three new `TestIsNewer` cases covering dev-ahead / dev-behind / dev-at-tag all pass
- [x] CLI build + full `wails build` both clean
- [x] Manually ran `gitbox update --check` on this branch from a dev build (`v1.3.0-6-g1dd7a91-dev`); output is `You are running the latest version` — no more spurious banner
- [ ] Dev build behind the latest tag still correctly shows the upgrade banner (covered by the new `v1.2.9-3-gabcdef-dev → v1.3.0` unit case; not manually exercised end-to-end since there's no older release to check against)