### PR TITLE
Fix orphan adoption picking wrong account when owner is an org

### DIFF
--- a/cmd/cli/scan_cmd.go
+++ b/cmd/cli/scan_cmd.go
@@ -154,6 +154,8 @@ Use --pull to also pull repos that are behind (fast-forward only).`,
 						tag = colorize(" [ORPHAN — local only]", colorYellow)
 					} else if o.MatchedAccount != "" {
 						tag = colorize(fmt.Sprintf(" [ORPHAN → %s]", o.MatchedAccount), colorYellow)
+					} else if len(o.AmbiguousCandidates) > 1 {
+						tag = colorize(fmt.Sprintf(" [ORPHAN — ambiguous: %s]", strings.Join(o.AmbiguousCandidates, " | ")), colorRed)
 					} else {
 						tag = colorize(" [ORPHAN — unknown account]", colorRed)
 					}

--- a/cmd/cli/tui/screen_settings.go
+++ b/cmd/cli/tui/screen_settings.go
@@ -125,7 +125,7 @@ func (m settingsModel) View() string {
 	b.WriteString(m.theme.TextMuted.Render(strings.Repeat("─", max(m.width, 40))) + "\n\n")
 
 	// Folder field.
-	label := "  Global folder: "
+	label := "  Root folder: "
 	if m.active == settingsFolder {
 		m.folderInput.Focus()
 		label = m.theme.Brand.Render(label)

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -563,15 +563,16 @@ func (a *App) ConfirmSweep(sourceKey, repoKey string) SweepDeleteDTO {
 
 // OrphanRepoDTO describes an orphan repo for the frontend.
 type OrphanRepoDTO struct {
-	Path           string `json:"path"`
-	RelPath        string `json:"relPath"`
-	RemoteURL      string `json:"remoteURL"`
-	RepoKey        string `json:"repoKey"`
-	MatchedAccount string `json:"matchedAccount"`
-	MatchedSource  string `json:"matchedSource"`
-	ExpectedPath   string `json:"expectedPath"`
-	NeedsRelocate  bool   `json:"needsRelocate"`
-	LocalOnly      bool   `json:"localOnly"`
+	Path                string   `json:"path"`
+	RelPath             string   `json:"relPath"`
+	RemoteURL           string   `json:"remoteURL"`
+	RepoKey             string   `json:"repoKey"`
+	MatchedAccount      string   `json:"matchedAccount"`
+	MatchedSource       string   `json:"matchedSource"`
+	ExpectedPath        string   `json:"expectedPath"`
+	NeedsRelocate       bool     `json:"needsRelocate"`
+	LocalOnly           bool     `json:"localOnly"`
+	AmbiguousCandidates []string `json:"ambiguousCandidates,omitempty"`
 }
 
 // AdoptResultDTO holds the result of adopting orphan repos.
@@ -596,15 +597,16 @@ func (a *App) FindOrphans() []OrphanRepoDTO {
 	dtos := make([]OrphanRepoDTO, len(orphans))
 	for i, o := range orphans {
 		dtos[i] = OrphanRepoDTO{
-			Path:           o.Path,
-			RelPath:        o.RelPath,
-			RemoteURL:      o.RemoteURL,
-			RepoKey:        o.RepoKey,
-			MatchedAccount: o.MatchedAccount,
-			MatchedSource:  o.MatchedSource,
-			ExpectedPath:   o.ExpectedPath,
-			NeedsRelocate:  o.NeedsRelocate,
-			LocalOnly:      o.LocalOnly,
+			Path:                o.Path,
+			RelPath:             o.RelPath,
+			RemoteURL:           o.RemoteURL,
+			RepoKey:             o.RepoKey,
+			MatchedAccount:      o.MatchedAccount,
+			MatchedSource:       o.MatchedSource,
+			ExpectedPath:        o.ExpectedPath,
+			NeedsRelocate:       o.NeedsRelocate,
+			LocalOnly:           o.LocalOnly,
+			AmbiguousCandidates: o.AmbiguousCandidates,
 		}
 	}
 	return dtos

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2397,7 +2397,7 @@
               <span class="adopt-repo-key">{o.repoKey}</span>
               <span class="adopt-target">&rarr; {o.matchedSource}</span>
               <span class="adopt-action">{o.needsRelocate ? 'relocate' : 'in place'}</span>
-              <span class="adopt-path"><span class="adopt-path-root">ROOT</span> {o.relPath}</span>
+              <span class="adopt-path"><span class="adopt-path-root">Root</span>/{o.relPath}</span>
             </label>
           {/each}
           {#each orphanModal.orphans.filter(o => !o.matchedAccount && !o.localOnly) as o, i}
@@ -2410,7 +2410,7 @@
               {#if o.ambiguousCandidates && o.ambiguousCandidates.length > 1}
                 <span class="adopt-hint">ambiguous: {o.ambiguousCandidates.join(' | ')}</span>
               {/if}
-              <span class="adopt-path adopt-path-muted"><span class="adopt-path-root">ROOT</span> {o.relPath}</span>
+              <span class="adopt-path adopt-path-muted"><span class="adopt-path-root">Root</span>/{o.relPath}</span>
             </div>
           {/each}
           {#each orphanModal.orphans.filter(o => o.localOnly) as o, i}
@@ -3604,16 +3604,13 @@
   .adopt-path-muted { padding-left: 0; }
   .adopt-path-root {
     display: inline-block;
-    padding: 1px 6px;
-    margin-right: 4px;
+    padding: 0 6px;
     background: var(--bg-secondary, rgba(128, 128, 128, 0.18));
     color: var(--text-secondary);
     border-radius: 3px;
     font-family: inherit;
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 600;
-    letter-spacing: 0.5px;
-    vertical-align: 1px;
   }
 
   .btn-adopt-confirm {

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -122,7 +122,7 @@
   let onboardError = '';
 
   async function browseFolder(target: 'onboard' | 'settings') {
-    const dir = await bridge.pickFolder('Choose clone folder');
+    const dir = await bridge.pickFolder('Choose root folder');
     if (dir) {
       if (target === 'onboard') onboardFolder = dir;
       else changeFolderPath = dir;
@@ -1793,7 +1793,7 @@
         <button class="settings-btn" on:click={() => bridge.openFileInEditor(configPath)}>Open in Editor</button>
       </div>
       <div class="settings-row">
-        <span class="settings-label">Clone folder</span>
+        <span class="settings-label">Root folder</span>
         <span class="settings-value">{$configStore?.global?.folder || '(not set)'}</span>
         <button class="settings-btn" on:click={openChangeFolder}>Change</button>
       </div>
@@ -2732,11 +2732,11 @@
     <div class="overlay" on:click={() => changeFolderModal = false} transition:fade={{ duration: 120 }}>
       <div class="modal modal-account" on:click|stopPropagation transition:slide={{ duration: 180 }}>
         <div class="modal-head">
-          <h3>Change clone folder</h3>
+          <h3>Change root folder</h3>
           <button class="btn-x" on:click={() => changeFolderModal = false}>&#10005;</button>
         </div>
         <div class="modal-body">
-          <p class="delete-warning delete-danger"><strong>WARNING:</strong> Changing the clone folder will <strong>not</strong> move existing clones. They will show as "Not local" until re-cloned at the new location (or moved manually).</p>
+          <p class="delete-warning delete-danger"><strong>WARNING:</strong> Changing the root folder will <strong>not</strong> move existing clones. They will show as "Not local" until re-cloned at the new location (or moved manually).</p>
           <div class="form-row" style="margin-top: 12px;">
             <label class="form-label">Current</label>
             <span class="settings-value">{$configStore?.global?.folder || '(not set)'}</span>

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2397,6 +2397,7 @@
               <span class="adopt-repo-key">{o.repoKey}</span>
               <span class="adopt-target">&rarr; {o.matchedSource}</span>
               <span class="adopt-action">{o.needsRelocate ? 'relocate' : 'in place'}</span>
+              <span class="adopt-path">{o.relPath}</span>
             </label>
           {/each}
           {#each orphanModal.orphans.filter(o => !o.matchedAccount && !o.localOnly) as o, i}
@@ -2409,6 +2410,7 @@
               {#if o.ambiguousCandidates && o.ambiguousCandidates.length > 1}
                 <span class="adopt-hint">ambiguous: {o.ambiguousCandidates.join(' | ')}</span>
               {/if}
+              <span class="adopt-path adopt-path-muted">{o.relPath}</span>
             </div>
           {/each}
           {#each orphanModal.orphans.filter(o => o.localOnly) as o, i}
@@ -3584,7 +3586,7 @@
   .adopt-section-local { color: var(--text-muted); }
 
   .adopt-item {
-    display: flex; align-items: center; gap: 8px;
+    display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
     padding: 3px 0; font-size: 12px; color: var(--text-primary);
   }
   .adopt-item input[type="checkbox"] { margin: 0; accent-color: #22c55e; }
@@ -3594,6 +3596,12 @@
   .adopt-action { color: var(--text-muted); font-size: 11px; font-style: italic; margin-left: auto; }
   .adopt-remote { color: var(--text-muted); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 300px; }
   .adopt-hint { color: #f59e0b; font-size: 11px; font-style: italic; margin-left: auto; }
+  .adopt-path {
+    flex-basis: 100%; padding-left: 22px;
+    color: var(--text-muted); font-size: 11px; font-family: var(--font-mono, monospace);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .adopt-path-muted { padding-left: 0; }
 
   .btn-adopt-confirm {
     padding: 6px 12px; background: #22c55e; border: none; color: #000;

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2397,7 +2397,7 @@
               <span class="adopt-repo-key">{o.repoKey}</span>
               <span class="adopt-target">&rarr; {o.matchedSource}</span>
               <span class="adopt-action">{o.needsRelocate ? 'relocate' : 'in place'}</span>
-              <span class="adopt-path">{o.relPath}</span>
+              <span class="adopt-path"><span class="adopt-path-root">Root folder/</span>{o.relPath}</span>
             </label>
           {/each}
           {#each orphanModal.orphans.filter(o => !o.matchedAccount && !o.localOnly) as o, i}
@@ -2410,7 +2410,7 @@
               {#if o.ambiguousCandidates && o.ambiguousCandidates.length > 1}
                 <span class="adopt-hint">ambiguous: {o.ambiguousCandidates.join(' | ')}</span>
               {/if}
-              <span class="adopt-path adopt-path-muted">{o.relPath}</span>
+              <span class="adopt-path adopt-path-muted"><span class="adopt-path-root">Root folder/</span>{o.relPath}</span>
             </div>
           {/each}
           {#each orphanModal.orphans.filter(o => o.localOnly) as o, i}
@@ -3602,6 +3602,7 @@
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .adopt-path-muted { padding-left: 0; }
+  .adopt-path-root { color: var(--text-secondary); font-family: inherit; }
 
   .btn-adopt-confirm {
     padding: 6px 12px; background: #22c55e; border: none; color: #000;

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2397,7 +2397,7 @@
               <span class="adopt-repo-key">{o.repoKey}</span>
               <span class="adopt-target">&rarr; {o.matchedSource}</span>
               <span class="adopt-action">{o.needsRelocate ? 'relocate' : 'in place'}</span>
-              <span class="adopt-path"><span class="adopt-path-root">Root folder/</span>{o.relPath}</span>
+              <span class="adopt-path"><span class="adopt-path-root">ROOT</span> {o.relPath}</span>
             </label>
           {/each}
           {#each orphanModal.orphans.filter(o => !o.matchedAccount && !o.localOnly) as o, i}
@@ -2410,7 +2410,7 @@
               {#if o.ambiguousCandidates && o.ambiguousCandidates.length > 1}
                 <span class="adopt-hint">ambiguous: {o.ambiguousCandidates.join(' | ')}</span>
               {/if}
-              <span class="adopt-path adopt-path-muted"><span class="adopt-path-root">Root folder/</span>{o.relPath}</span>
+              <span class="adopt-path adopt-path-muted"><span class="adopt-path-root">ROOT</span> {o.relPath}</span>
             </div>
           {/each}
           {#each orphanModal.orphans.filter(o => o.localOnly) as o, i}
@@ -3602,7 +3602,19 @@
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .adopt-path-muted { padding-left: 0; }
-  .adopt-path-root { color: var(--text-secondary); font-family: inherit; }
+  .adopt-path-root {
+    display: inline-block;
+    padding: 1px 6px;
+    margin-right: 4px;
+    background: var(--bg-secondary, rgba(128, 128, 128, 0.18));
+    color: var(--text-secondary);
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    vertical-align: 1px;
+  }
 
   .btn-adopt-confirm {
     padding: 6px 12px; background: #22c55e; border: none; color: #000;

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2406,6 +2406,9 @@
             <div class="adopt-item adopt-item-muted">
               <span class="adopt-repo-key">{o.repoKey}</span>
               <span class="adopt-remote">{o.remoteURL}</span>
+              {#if o.ambiguousCandidates && o.ambiguousCandidates.length > 1}
+                <span class="adopt-hint">ambiguous: {o.ambiguousCandidates.join(' | ')}</span>
+              {/if}
             </div>
           {/each}
           {#each orphanModal.orphans.filter(o => o.localOnly) as o, i}
@@ -3590,6 +3593,7 @@
   .adopt-target { color: var(--text-secondary); font-size: 11px; }
   .adopt-action { color: var(--text-muted); font-size: 11px; font-style: italic; margin-left: auto; }
   .adopt-remote { color: var(--text-muted); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 300px; }
+  .adopt-hint { color: #f59e0b; font-size: 11px; font-style: italic; margin-left: auto; }
 
   .btn-adopt-confirm {
     padding: 6px 12px; background: #22c55e; border: none; color: #000;

--- a/cmd/gui/frontend/src/lib/types.ts
+++ b/cmd/gui/frontend/src/lib/types.ts
@@ -149,6 +149,7 @@ export interface OrphanRepoDTO {
   expectedPath: string;
   needsRelocate: boolean;
   localOnly: boolean;
+  ambiguousCandidates?: string[];
 }
 
 export interface AdoptResultDTO {

--- a/cmd/gui/frontend/wailsjs/go/models.ts
+++ b/cmd/gui/frontend/wailsjs/go/models.ts
@@ -542,6 +542,7 @@ export namespace main {
 	    expectedPath: string;
 	    needsRelocate: boolean;
 	    localOnly: boolean;
+	    ambiguousCandidates?: string[];
 	
 	    static createFrom(source: any = {}) {
 	        return new OrphanRepoDTO(source);
@@ -558,6 +559,7 @@ export namespace main {
 	        this.expectedPath = source["expectedPath"];
 	        this.needsRelocate = source["needsRelocate"];
 	        this.localOnly = source["localOnly"];
+	        this.ambiguousCandidates = source["ambiguousCandidates"];
 	    }
 	}
 	export class RepoDetail {

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -34,7 +34,7 @@ The GUI requires a desktop environment with a display server (X11 or Wayland).
 
 ## Step 1: First launch
 
-The first time you open Gitbox, it asks you to pick a **clone folder** — this is where all your projects will live on disk. Something like `~/00.git` or `C:\repos` works well.
+The first time you open Gitbox, it asks you to pick a **root folder** — this is where all your projects will live on disk. Something like `~/00.git` or `C:\repos` works well.
 
 Click **Get started** and you're in.
 
@@ -244,7 +244,7 @@ This is useful when you want gitbox visible as a sidebar while working in other 
 Click the **gear icon** to open the settings panel:
 
 - **Config** — shows the path to your config file with an "Open in Editor" button
-- **Clone folder** — where projects are stored, with a "Change" button
+- **Root folder** — where projects are stored, with a "Change" button
 - **Theme** — switch between System, Light, and Dark
 - **Periodic fetch** — automatic fetch interval (off, 5m, 15m, 30m)
 - **Run at startup** — launch Gitbox automatically when you log in (platform dependent)

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -129,6 +129,15 @@ Click a repo that shows local changes, conflicts, or other issues. An expandable
 
 This detail view **updates automatically** when Gitbox detects new changes — you don't need to close and reopen it.
 
+### Adopting orphan repos
+
+The orphans modal lists clones under your parent folder that aren't yet in `gitbox.json`, grouped by how Gitbox can handle them:
+
+- **Ready to adopt** — Gitbox matched the clone to an account using its remote URL, the repo's `credential.<url>.username`, or the folder it lives under. Check the box and click **Adopt** to register it (and optionally relocate it to the canonical path).
+- **Unknown account** — no configured account matches the remote host. Add an account first, then re-open the modal.
+- **Unknown account, `ambiguous: a | b`** — two or more accounts on the same host tie on every identity signal Gitbox looks at. The checkbox is disabled so no files are moved. To disambiguate: move the clone under the correct source subtree, edit `gitbox.json` to reflect the intended account, or set `credential.<url>.username` in the clone, then re-open the modal.
+- **Local only** — no `origin` remote, not adoptable.
+
 ### Creating repositories
 
 Click **Create repo** on an account card to create a new repository directly on the provider without leaving Gitbox.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -353,6 +353,25 @@ Unlike `status`, `scan` does not require a gitbox configuration — it works on 
 
 When a gitbox configuration exists and scanning inside the parent folder, repos are annotated as `[tracked]` or `[ORPHAN]` with account-matching hints and a summary count.
 
+Orphan tags:
+
+- `[ORPHAN → <account>]` — scan matched the orphan to a configured account.
+- `[ORPHAN — local only]` — repo has no `origin` remote.
+- `[ORPHAN — unknown account]` — no host-matching account is configured.
+- `[ORPHAN — ambiguous: a | b]` — two or more accounts on the same host tie on every identity signal. Move the folder under the right source subtree, edit `gitbox.json`, or set `credential.<url>.username` in the repo to disambiguate, then re-scan.
+
+To pick an account for an orphan, gitbox scores each host-matching account using the signals below (all values are additive, higher wins):
+
+| Signal | Score | Source |
+| --- | --- | --- |
+| Host match (required baseline) | 1 | account URL hostname or SSH alias vs the parsed remote host |
+| Owner equals `account.username` | +3 | owner segment of the remote URL path |
+| Repo lives under the account's source folder | +5 | first path component of the repo relative to the gitbox parent folder |
+| HTTPS URL embeds `user@` where user equals `account.username` | +10 | `url.User.Username()` of the origin remote |
+| `.git/config` has `credential.<url>.username` equal to `account.username` | +10 | `git config --get-regexp '^credential\..*\.username$'` in the repo |
+
+If the top score is shared by two or more accounts (including a bare host-only tie) the match is marked ambiguous: no account is picked, no files are moved, and the scan and GUI surface the candidate list.
+
 ---
 
 ## Adopting

--- a/pkg/adopt/adopt.go
+++ b/pkg/adopt/adopt.go
@@ -16,18 +16,19 @@ import (
 
 // OrphanRepo describes a git repo on disk not tracked in gitbox.json.
 type OrphanRepo struct {
-	Path           string // absolute path on disk
-	RelPath        string // relative to parent folder
-	RemoteURL      string // origin remote URL (empty if local-only)
-	Host           string // extracted hostname from remote
-	Owner          string // extracted owner/org from remote
-	Repo           string // extracted repo name from remote
-	RepoKey        string // "owner/repo" — the key for config.AddRepo
-	MatchedAccount string // account key if matched, empty if unknown
-	MatchedSource  string // source key if matched, empty if needs creation
-	ExpectedPath   string // where gitbox convention says this should live
-	NeedsRelocate  bool   // current path != expected path
-	LocalOnly      bool   // no remote — cannot adopt
+	Path                string   // absolute path on disk
+	RelPath             string   // relative to parent folder
+	RemoteURL           string   // origin remote URL (empty if local-only)
+	Host                string   // extracted hostname from remote
+	Owner               string   // extracted owner/org from remote
+	Repo                string   // extracted repo name from remote
+	RepoKey             string   // "owner/repo" — the key for config.AddRepo
+	MatchedAccount      string   // account key if matched, empty if unknown/ambiguous
+	MatchedSource       string   // source key if matched, empty if needs creation
+	ExpectedPath        string   // where gitbox convention says this should live
+	NeedsRelocate       bool     // current path != expected path
+	LocalOnly           bool     // no remote — cannot adopt
+	AmbiguousCandidates []string // when multiple host-matching accounts tie with no disambiguator
 }
 
 // FindOrphans walks the gitbox parent folder and returns repos not in config.
@@ -81,10 +82,18 @@ func FindOrphans(cfg *config.Config) ([]OrphanRepo, error) {
 		o.Repo = repo
 		o.RepoKey = owner + "/" + repo
 
-		// Match against accounts.
-		acctKey, srcKey := MatchAccount(cfg, host, owner)
+		// Match against accounts using the richer identity signals.
+		mc := MatchContext{
+			Host:         host,
+			Owner:        owner,
+			RemoteURL:    remoteURL,
+			RepoPath:     absPath,
+			ParentFolder: parentFolder,
+		}
+		acctKey, srcKey, ambiguous := MatchAccountEx(cfg, mc)
 		o.MatchedAccount = acctKey
 		o.MatchedSource = srcKey
+		o.AmbiguousCandidates = ambiguous
 
 		// Compute expected path and relocation need.
 		if srcKey != "" {
@@ -140,41 +149,140 @@ func trackedPaths(cfg *config.Config, parentFolder string) map[string]bool {
 	return paths
 }
 
+// MatchContext carries every signal MatchAccountEx uses to pick an account.
+// Host and Owner are always required; the rest are optional and, when absent,
+// simply don't contribute to scoring.
+type MatchContext struct {
+	Host         string // hostname parsed from the remote URL (or SSH alias)
+	Owner        string // owner/org parsed from the remote URL path
+	RemoteURL    string // full remote URL (used to extract an embedded user)
+	RepoPath     string // repo path on disk (used for credential + parent-folder signals)
+	ParentFolder string // gitbox parent folder (used to compute parent-folder source match)
+}
+
+// Score weights for MatchAccountEx. The thresholds are picked so that:
+//   - hostWeight alone never claims a match (ambiguous when ≥2 candidates tie).
+//   - Any non-host signal unambiguously beats host-only.
+//   - credentialWeight and urlUserWeight are the strongest — they directly name
+//     the account's Username in the repo's own state.
+const (
+	hostWeight        = 1
+	ownerWeight       = 3
+	parentFolderScore = 5
+	urlUserWeight     = 10
+	credentialWeight  = 10
+)
+
 // MatchAccount finds the best account + source for a remote host and owner.
-// Returns (accountKey, sourceKey) — both empty if no match.
+// Returns (accountKey, sourceKey) — both empty if no match or the match is
+// ambiguous.
+//
+// Kept for API compatibility; new callers should use MatchAccountEx to get
+// access to the full signal set and ambiguity information.
 func MatchAccount(cfg *config.Config, host, owner string) (string, string) {
+	acct, src, _ := MatchAccountEx(cfg, MatchContext{Host: host, Owner: owner})
+	return acct, src
+}
+
+// MatchAccountEx scores every host-matching account against the signals in mc
+// and returns the best match. Returns empty account/source keys when no
+// account matches the host or when the top score is tied across ≥2 accounts
+// (the tied candidates are returned in ambiguous).
+func MatchAccountEx(cfg *config.Config, mc MatchContext) (accountKey, sourceKey string, ambiguous []string) {
 	type candidate struct {
 		accountKey string
 		sourceKey  string
-		score      int // higher is better
+		score      int
 	}
-	var candidates []candidate
 
-	for acctKey, acct := range cfg.Accounts {
+	// Precompute signals that do not depend on any specific account.
+	embeddedUser := ""
+	if mc.RemoteURL != "" {
+		embeddedUser = git.RemoteURLUser(mc.RemoteURL)
+	}
+	var credUsers []string
+	if mc.RepoPath != "" {
+		credUsers = git.CredentialUsernames(mc.RepoPath)
+	}
+	// First path component of the repo relative to the gitbox parent folder.
+	// For a canonical layout "parent/sourceFolder/owner/repo" this is the
+	// source folder name; for a flat layout "parent/sourceFolder/repo" it is
+	// still the source folder name. That's the signal we want.
+	repoSourceFolder := ""
+	if mc.RepoPath != "" && mc.ParentFolder != "" {
+		if rel, err := filepath.Rel(mc.ParentFolder, mc.RepoPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			parts := strings.Split(filepath.ToSlash(rel), "/")
+			if len(parts) > 0 {
+				repoSourceFolder = parts[0]
+			}
+		}
+	}
+
+	// Iterate accounts deterministically so the scoring itself is stable
+	// even before the tie-breaker decides ambiguity.
+	acctKeys := make([]string, 0, len(cfg.Accounts))
+	for k := range cfg.Accounts {
+		acctKeys = append(acctKeys, k)
+	}
+	sort.Strings(acctKeys)
+
+	var candidates []candidate
+	for _, acctKey := range acctKeys {
+		acct := cfg.Accounts[acctKey]
 		acctHost := HostnameFromURL(acct.URL)
 
-		// Check direct hostname match.
-		hostMatch := strings.EqualFold(host, acctHost)
-
-		// Check SSH host alias match (e.g., host="gitbox-github-luis", alias="gitbox-github-luis").
+		hostMatch := strings.EqualFold(mc.Host, acctHost)
 		if !hostMatch && acct.SSH != nil && acct.SSH.Host != "" {
-			hostMatch = strings.EqualFold(host, acct.SSH.Host)
+			hostMatch = strings.EqualFold(mc.Host, acct.SSH.Host)
 		}
-
 		if !hostMatch {
 			continue
 		}
 
-		// Score: host match = 1, username match = +2
-		score := 1
-		if strings.EqualFold(owner, acct.Username) {
-			score += 2
+		score := hostWeight
+
+		// Owner == account Username.
+		if acct.Username != "" && strings.EqualFold(mc.Owner, acct.Username) {
+			score += ownerWeight
 		}
 
-		// Find a source linked to this account.
+		// Embedded HTTPS user.
+		if embeddedUser != "" && acct.Username != "" && strings.EqualFold(embeddedUser, acct.Username) {
+			score += urlUserWeight
+		}
+
+		// credential.<url>.username in the repo's own config.
+		if acct.Username != "" {
+			for _, cu := range credUsers {
+				if strings.EqualFold(cu, acct.Username) {
+					score += credentialWeight
+					break
+				}
+			}
+		}
+
+		// Repo lives under this account's source folder.
+		if repoSourceFolder != "" {
+			for sk, src := range cfg.Sources {
+				if src.Account != acctKey {
+					continue
+				}
+				if strings.EqualFold(repoSourceFolder, src.EffectiveFolder(sk)) {
+					score += parentFolderScore
+					break
+				}
+			}
+		}
+
+		// Pick a source linked to this account (deterministic iteration).
 		srcKey := ""
-		for sk, src := range cfg.Sources {
-			if src.Account == acctKey {
+		srcKeys := make([]string, 0, len(cfg.Sources))
+		for sk := range cfg.Sources {
+			srcKeys = append(srcKeys, sk)
+		}
+		sort.Strings(srcKeys)
+		for _, sk := range srcKeys {
+			if cfg.Sources[sk].Account == acctKey {
 				srcKey = sk
 				break
 			}
@@ -184,14 +292,28 @@ func MatchAccount(cfg *config.Config, host, owner string) (string, string) {
 	}
 
 	if len(candidates) == 0 {
-		return "", ""
+		return "", "", nil
 	}
 
-	// Pick the best match (highest score).
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].score > candidates[j].score
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].accountKey < candidates[j].accountKey
 	})
-	return candidates[0].accountKey, candidates[0].sourceKey
+
+	top := candidates[0]
+	// Collect every candidate tied at the top score.
+	tied := []string{top.accountKey}
+	for _, c := range candidates[1:] {
+		if c.score == top.score {
+			tied = append(tied, c.accountKey)
+		}
+	}
+	if len(tied) >= 2 {
+		return "", "", tied
+	}
+	return top.accountKey, top.sourceKey, nil
 }
 
 // PlainRemoteURL builds a remote URL without embedded credentials.

--- a/pkg/adopt/adopt_test.go
+++ b/pkg/adopt/adopt_test.go
@@ -226,6 +226,181 @@ func TestMatchAccount(t *testing.T) {
 	}
 }
 
+// twoGithubConfig returns a config with two github.com accounts and a
+// Forgejo account — the configuration shape that triggers the #35 bug.
+func twoGithubConfig(parentFolder string) *config.Config {
+	return &config.Config{
+		Version: 2,
+		Global:  config.GlobalConfig{Folder: parentFolder},
+		Accounts: map[string]config.Account{
+			"github-personal": {
+				Provider: "github",
+				URL:      "https://github.com",
+				Username: "user-a",
+				Name:     "User A",
+				Email:    "a@test.com",
+			},
+			"github-work": {
+				Provider: "github",
+				URL:      "https://github.com",
+				Username: "user-b",
+				Name:     "User B",
+				Email:    "b@test.com",
+			},
+			"forgejo-misc": {
+				Provider: "forgejo",
+				URL:      "https://forgejo.example.com",
+				Username: "luis",
+			},
+		},
+		Sources: map[string]config.Source{
+			"github-personal": {Account: "github-personal", Repos: map[string]config.Repo{}},
+			"github-work":     {Account: "github-work", Repos: map[string]config.Repo{}},
+			"forgejo-misc":    {Account: "forgejo-misc", Repos: map[string]config.Repo{}},
+		},
+		SourceOrder: []string{"github-personal", "github-work", "forgejo-misc"},
+	}
+}
+
+func TestMatchAccountEx_EmbeddedURLUser(t *testing.T) {
+	root := t.TempDir()
+	cfg := twoGithubConfig(root)
+
+	// Orphan at ~/root/github-personal/org-a/repo-a with remote embedding user-b
+	// (the Username of github-work). Without the URL-user signal this would
+	// tie on host alone and pick the wrong account.
+	orphanPath := filepath.Join(root, "github-personal", "org-a", "repo-a")
+	if err := os.MkdirAll(orphanPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	acct, _, amb := MatchAccountEx(cfg, MatchContext{
+		Host:         "github.com",
+		Owner:        "org-a",
+		RemoteURL:    "https://user-b@github.com/org-a/repo-a.git",
+		RepoPath:     orphanPath,
+		ParentFolder: root,
+	})
+	if acct != "github-work" {
+		t.Errorf("account = %q, want github-work (URL-user signal should win)", acct)
+	}
+	if len(amb) != 0 {
+		t.Errorf("expected unambiguous match, got candidates %v", amb)
+	}
+}
+
+func TestMatchAccountEx_CredentialUsername(t *testing.T) {
+	root := t.TempDir()
+	cfg := twoGithubConfig(root)
+
+	orphanPath := filepath.Join(root, "misc", "repo")
+	initBareRepo(t, orphanPath, "https://github.com/org-a/repo.git")
+
+	// Set credential.<url>.username in the repo — simulates what `git clone`
+	// with a specific account leaves behind.
+	cmd := exec.Command("git", "config", "credential.https://github.com.username", "user-b")
+	cmd.Dir = orphanPath
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+t.TempDir())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v\n%s", err, out)
+	}
+
+	acct, _, amb := MatchAccountEx(cfg, MatchContext{
+		Host:         "github.com",
+		Owner:        "org-a",
+		RemoteURL:    "https://github.com/org-a/repo.git",
+		RepoPath:     orphanPath,
+		ParentFolder: root,
+	})
+	if acct != "github-work" {
+		t.Errorf("account = %q, want github-work (credential username signal)", acct)
+	}
+	if len(amb) != 0 {
+		t.Errorf("expected unambiguous match, got candidates %v", amb)
+	}
+}
+
+func TestMatchAccountEx_ParentFolderMatch(t *testing.T) {
+	root := t.TempDir()
+	cfg := twoGithubConfig(root)
+
+	// Orphan sits under the github-work source folder — that alone should
+	// break the tie when no stronger signal fires.
+	orphanPath := filepath.Join(root, "github-work", "org-a", "repo")
+	if err := os.MkdirAll(orphanPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	acct, _, amb := MatchAccountEx(cfg, MatchContext{
+		Host:         "github.com",
+		Owner:        "org-a",
+		RemoteURL:    "https://github.com/org-a/repo.git",
+		RepoPath:     orphanPath,
+		ParentFolder: root,
+	})
+	if acct != "github-work" {
+		t.Errorf("account = %q, want github-work (parent-folder signal)", acct)
+	}
+	if len(amb) != 0 {
+		t.Errorf("expected unambiguous match, got candidates %v", amb)
+	}
+}
+
+func TestMatchAccountEx_Ambiguous(t *testing.T) {
+	root := t.TempDir()
+	cfg := twoGithubConfig(root)
+
+	// Orphan lives off to the side (no parent-folder signal) with a plain
+	// remote URL (no embedded user, no credential helper) and an org owner
+	// that matches neither Username. Both github accounts tie at host=1.
+	orphanPath := filepath.Join(root, "elsewhere", "org-c", "repo")
+	if err := os.MkdirAll(orphanPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	acct, src, amb := MatchAccountEx(cfg, MatchContext{
+		Host:         "github.com",
+		Owner:        "org-c",
+		RemoteURL:    "https://github.com/org-c/repo.git",
+		RepoPath:     orphanPath,
+		ParentFolder: root,
+	})
+	if acct != "" || src != "" {
+		t.Errorf("expected empty acct/src on ambiguous match, got %q/%q", acct, src)
+	}
+	if len(amb) != 2 {
+		t.Fatalf("expected 2 tied candidates, got %d: %v", len(amb), amb)
+	}
+	seen := map[string]bool{}
+	for _, c := range amb {
+		seen[c] = true
+	}
+	if !seen["github-personal"] || !seen["github-work"] {
+		t.Errorf("expected github-personal and github-work in candidates, got %v", amb)
+	}
+}
+
+func TestMatchAccountEx_UnambiguousWhenOnlyOneHostMatches(t *testing.T) {
+	// Regression guard: with exactly one host-matching account, score=1 alone
+	// is enough (no tie possible).
+	root := t.TempDir()
+	cfg := twoGithubConfig(root)
+	orphanPath := filepath.Join(root, "x", "y", "z")
+	acct, _, amb := MatchAccountEx(cfg, MatchContext{
+		Host:         "forgejo.example.com",
+		Owner:        "some-org",
+		RemoteURL:    "https://forgejo.example.com/some-org/repo.git",
+		RepoPath:     orphanPath,
+		ParentFolder: root,
+	})
+	if acct != "forgejo-misc" {
+		t.Errorf("account = %q, want forgejo-misc", acct)
+	}
+	if len(amb) != 0 {
+		t.Errorf("expected no ambiguity, got %v", amb)
+	}
+}
+
 func TestHostnameFromURL(t *testing.T) {
 	tests := []struct {
 		url  string

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -385,6 +385,31 @@ func ConfigGet(repoPath, key string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// CredentialUsernames returns every value of repo-local git config keys that
+// match `credential.<url>.username`. Returns nil if none are set. Errors from
+// git (including "no match", which exits 1) are swallowed — a repo without
+// credential usernames is a normal case, not a failure.
+func CredentialUsernames(repoPath string) []string {
+	out, err := output(repoPath, "config", "--get-regexp", `^credential\..*\.username$`)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Lines look like: "credential.https://github.com.username SW-Luis-Palacios"
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		names = append(names, fields[len(fields)-1])
+	}
+	return names
+}
+
 // ConfigSet sets a git config value in the given repo.
 func ConfigSet(repoPath, key, value string) error {
 	return run(repoPath, "config", key, value)

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -188,6 +188,38 @@ func TestConfigGetSet(t *testing.T) {
 	}
 }
 
+func TestCredentialUsernames(t *testing.T) {
+	clonePath, _ := initTestRepo(t)
+
+	// No credential.*.username keys set → expect nil.
+	if names := CredentialUsernames(clonePath); len(names) != 0 {
+		t.Errorf("expected no usernames, got %v", names)
+	}
+
+	// Set one credential.<url>.username and one unrelated credential.<url>.* key.
+	if err := ConfigSet(clonePath, "credential.https://example.com.username", "user-a"); err != nil {
+		t.Fatalf("ConfigSet: %v", err)
+	}
+	if err := ConfigSet(clonePath, "credential.https://example.com.helper", "manager"); err != nil {
+		t.Fatalf("ConfigSet: %v", err)
+	}
+	if err := ConfigSet(clonePath, "credential.https://other.example.com.username", "user-b"); err != nil {
+		t.Fatalf("ConfigSet: %v", err)
+	}
+
+	names := CredentialUsernames(clonePath)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 usernames, got %d: %v", len(names), names)
+	}
+	seen := map[string]bool{}
+	for _, n := range names {
+		seen[n] = true
+	}
+	if !seen["user-a"] || !seen["user-b"] {
+		t.Errorf("expected user-a and user-b, got %v", names)
+	}
+}
+
 func TestCurrentBranch(t *testing.T) {
 	clonePath, _ := initTestRepo(t)
 

--- a/pkg/git/url.go
+++ b/pkg/git/url.go
@@ -60,6 +60,22 @@ func ParseRemoteURL(rawURL string) (host, owner, repo string, err error) {
 	return host, owner, repo, nil
 }
 
+// RemoteURLUser extracts the user part of an HTTPS URL of the form
+// "https://user@host/...". Returns "" for URLs without an embedded user,
+// for SSH URLs (where the user is always "git" and carries no account signal),
+// and for malformed input.
+func RemoteURLUser(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" || !strings.Contains(rawURL, "://") {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return ""
+	}
+	return u.User.Username()
+}
+
 // splitOwnerRepo splits "owner/repo" or "group/subgroup/repo" into
 // (owner, repo) where owner may contain slashes for nested groups.
 func splitOwnerRepo(path string) (owner, repo string) {

--- a/pkg/git/url_test.go
+++ b/pkg/git/url_test.go
@@ -64,6 +64,30 @@ func TestParseRemoteURL(t *testing.T) {
 	}
 }
 
+func TestRemoteURLUser(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://user@github.com/owner/repo.git", "user"},
+		{"https://user:token@github.com/owner/repo.git", "user"},
+		{"https://github.com/owner/repo.git", ""},
+		{"https://github.com/owner/repo", ""},
+		{"git@github.com:owner/repo.git", ""},
+		{"git@gitbox-github-luis:owner/repo.git", ""},
+		{"", ""},
+		{"not-a-url", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			got := RemoteURLUser(tt.url)
+			if got != tt.want {
+				t.Errorf("RemoteURLUser(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSplitOwnerRepo(t *testing.T) {
 	tests := []struct {
 		path      string


### PR DESCRIPTION
Closes #35

## What changed

- `pkg/adopt.MatchAccount` tie-broke on Go map iteration order when two host-matching accounts both scored 1 (owner != any `Username`). Introduced `MatchAccountEx` with a richer `MatchContext` and five weighted signals (host, owner/Username, parent source folder, HTTPS-embedded user, repo-local `credential.<url>.username`). Any non-host signal decisively beats host-only; a top-score tie across ≥2 accounts returns empty with `AmbiguousCandidates` populated so adoption stays no-op.
- Two new `pkg/git` helpers feed the matcher: `RemoteURLUser` (extracts `user@` from HTTPS URLs) and `CredentialUsernames` (reads `credential.<url>.username` keys from a repo's config).
- `OrphanRepoDTO` carries `AmbiguousCandidates` to the GUI. Orphan modal renders an inline `ambiguous: a | b` hint on tied rows (checkbox already disabled for non-matched). `gitbox scan` prints `[ORPHAN — ambiguous: a | b]` for the same case.
- UX polish while editing the modal: each row gets a `Root/<relative path>` subline — "Root" rendered as a compact pill — so rows with the same repo key in different subtrees are distinguishable and orphans sitting directly under the root read naturally.
- Consistency rename: GUI settings label, change-folder modal, folder-picker dialog, and TUI settings screen all use "Root folder" (previously a mix of "Clone folder" and "Global folder").
- Docs updated: `docs/reference.md` explains the scoring table and the `[ORPHAN — ambiguous]` tag; `docs/gui-guide.md` gets a short orphan-modal section and the renamed label.

## Test plan

- [ ] `go vet ./...` clean
- [ ] `go test -short ./...` passes (new tests: `TestRemoteURLUser`, `TestCredentialUsernames`, `TestMatchAccountEx_EmbeddedURLUser`, `TestMatchAccountEx_CredentialUsername`, `TestMatchAccountEx_ParentFolderMatch`, `TestMatchAccountEx_Ambiguous`, `TestMatchAccountEx_UnambiguousWhenOnlyOneHostMatches`)
- [ ] `go build ./cmd/cli` succeeds; `wails build` in `cmd/gui` succeeds
- [ ] With two accounts on the same host configured and an orphan whose remote owner matches neither `Username`, `gitbox scan` picks the correct account via the URL-user / credential / parent-folder signal; GUI modal routes it to the right source under "Ready to adopt"
- [ ] Truly ambiguous case (no disambiguator) surfaces as `[ORPHAN — ambiguous: a | b]` in scan and under "Unknown account" with the `ambiguous:` hint in the modal; no files moved
- [ ] GUI + TUI settings show "Root folder"; orphan modal subline shows the `Root/` pill