### PR TITLE
Smarter clone & account kebab: default + submenus, TUI launcher keys

### DIFF
--- a/cmd/cli/tui/launchers.go
+++ b/cmd/cli/tui/launchers.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	"github.com/LuisPalacios/gitbox/pkg/git"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// launchDoneMsg reports the outcome of a launch action so the origin screen
+// can surface a status/error line without needing separate message types per
+// kind.
+type launchDoneMsg struct {
+	target string // short label for status line ("VS Code", "Git Bash", ...)
+	err    error
+}
+
+// launchEditorCmd opens a folder in a GUI editor. On Windows, editor CLIs
+// like code.cmd are batch wrappers that exit immediately after launching the
+// editor's own window, so no console-flash workaround is needed here (the TUI
+// owns the console; the wrapper briefly shares it and exits).
+func launchEditorCmd(path, command, name string) tea.Cmd {
+	return func() tea.Msg {
+		if command == "" {
+			return launchDoneMsg{target: name, err: fmt.Errorf("editor command is empty")}
+		}
+		cmd := exec.Command(command, path)
+		cmd.Env = git.Environ()
+		if err := cmd.Start(); err != nil {
+			return launchDoneMsg{target: name, err: err}
+		}
+		return launchDoneMsg{target: name}
+	}
+}
+
+// launchTerminalCmd spawns a terminal emulator in the given folder. The
+// terminal command is expected to open its own window (wt.exe, open -a
+// Terminal, gnome-terminal …), so the TUI's stdio is never taken over.
+func launchTerminalCmd(path string, term config.TerminalEntry) tea.Cmd {
+	return func() tea.Msg {
+		if term.Command == "" {
+			return launchDoneMsg{target: term.Name, err: fmt.Errorf("terminal command is empty")}
+		}
+		args := resolveTerminalArgs(term.Args, path, nil)
+		cmd := exec.Command(term.Command, args...)
+		cmd.Env = git.Environ()
+		if err := cmd.Start(); err != nil {
+			return launchDoneMsg{target: term.Name, err: err}
+		}
+		return launchDoneMsg{target: term.Name}
+	}
+}
+
+// launchAIHarnessCmd spawns the given AI harness inside the first configured
+// terminal (mirrors the GUI contract: harnesses are CLI-only and must run in
+// a terminal). Returns an actionable error if no terminal is configured.
+func launchAIHarnessCmd(path string, h config.AIHarnessEntry, terminals []config.TerminalEntry) tea.Cmd {
+	return func() tea.Msg {
+		if h.Command == "" {
+			return launchDoneMsg{target: h.Name, err: fmt.Errorf("harness command is empty")}
+		}
+		if len(terminals) == 0 {
+			return launchDoneMsg{target: h.Name, err: fmt.Errorf("configure at least one terminal in global.terminals to launch AI harnesses")}
+		}
+		term := terminals[0]
+		harnessArgv := append([]string{h.Command}, h.Args...)
+		args := resolveTerminalArgs(term.Args, path, harnessArgv)
+		cmd := exec.Command(term.Command, args...)
+		cmd.Env = git.Environ()
+		if err := cmd.Start(); err != nil {
+			return launchDoneMsg{target: h.Name, err: err}
+		}
+		return launchDoneMsg{target: h.Name}
+	}
+}
+
+// resolveTerminalArgs substitutes {path} and splices {command} in terminal
+// args. Mirrors the GUI's resolveTerminalArgsWithCommand (cmd/gui/app.go) so
+// both frontends interpret config the same way. Kept local to the TUI to
+// avoid introducing a public pkg surface just for two call sites.
+func resolveTerminalArgs(args []string, path string, harnessArgv []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	pathSubstituted := false
+	out := make([]string, 0, len(args)+len(harnessArgv))
+	for _, a := range args {
+		if a == "{command}" {
+			out = append(out, harnessArgv...)
+			continue
+		}
+		if strings.Contains(a, "{path}") {
+			out = append(out, strings.ReplaceAll(a, "{path}", path))
+			pathSubstituted = true
+			continue
+		}
+		out = append(out, a)
+	}
+	if !pathSubstituted && harnessArgv == nil {
+		out = append(out, path)
+	}
+	return out
+}

--- a/cmd/cli/tui/screen_account.go
+++ b/cmd/cli/tui/screen_account.go
@@ -40,6 +40,7 @@ type accountModel struct {
 	deleteInput   textinput.Model
 	editForm      formModel
 	renameForm    formModel
+	launcher      launcherOverlay
 }
 
 func newAccountModel(cfg *config.Config, cfgPath string, credMgr *credential.StatusManager, theme styles.Theme, w, h int, selectedKey string) accountModel {
@@ -55,6 +56,7 @@ func newAccountModel(cfg *config.Config, cfgPath string, credMgr *credential.Sta
 		height:      h,
 		selectedKey: selectedKey,
 		deleteInput: ti,
+		launcher:    newLauncherOverlay(cfg),
 	}
 }
 
@@ -66,6 +68,16 @@ func (m accountModel) Init() tea.Cmd {
 }
 
 func (m accountModel) Update(msg tea.Msg) (accountModel, tea.Cmd) {
+	// Launcher overlay intercepts input when active. It's only enabled from
+	// accountViewDetail so form views (edit/rename) keep full keyboard
+	// control over their text inputs.
+	if lo, cmd, handled := m.launcher.update(msg, m.cfg.Global.Terminals); handled {
+		m.launcher = lo
+		m.statusMsg = ""
+		m.errMsg = ""
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// Delete flow intercepts all keys when active.
@@ -182,6 +194,19 @@ func (m accountModel) Update(msg tea.Msg) (accountModel, tea.Cmd) {
 			m.statusMsg = ""
 			m.errMsg = ""
 			return m, openAccountFolderCmd(path)
+
+		case msg.String() == "t" && m.view == accountViewDetail:
+			return m.launchAccountTerminal()
+
+		case msg.String() == "a" && m.view == accountViewDetail:
+			return m.launchAccountHarness()
+
+		case msg.String() == "O" && m.view == accountViewDetail:
+			// Capital O: full launcher overlay. Lowercase o stays bound to
+			// "open folder" so existing muscle memory isn't broken; the
+			// editor default lives inside the launcher because lowercase e
+			// is taken by the edit form.
+			return m.openAccountLauncher()
 		}
 
 	case credStatusUpdatedMsg:
@@ -212,6 +237,14 @@ func (m accountModel) Update(msg tea.Msg) (accountModel, tea.Cmd) {
 			m.errMsg = msg.err.Error()
 		} else {
 			m.statusMsg = "Opened folder."
+		}
+		return m, nil
+
+	case launchDoneMsg:
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+		} else {
+			m.statusMsg = "Opened in " + msg.target + "."
 		}
 		return m, nil
 
@@ -445,9 +478,22 @@ func (m accountModel) viewDetail() string {
 	if (acct.DefaultCredentialType == "ssh" || acct.DefaultCredentialType == "gcm") && credResult.PAT != credential.StatusOK {
 		hints = append(hints, "p PAT")
 	}
-	hints = append(hints, "d discover", "v verify", "b browser", "o folder", "D delete", "ESC back")
+	hints = append(hints, "d discover", "v verify", "b browser", "o folder")
+	if len(m.cfg.Global.Terminals) > 0 {
+		hints = append(hints, "t terminal")
+	}
+	if len(m.cfg.Global.AIHarnesses) > 0 {
+		hints = append(hints, "a AI")
+	}
+	if m.launcher.hasAny() {
+		hints = append(hints, "O open in…")
+	}
+	hints = append(hints, "D delete", "ESC back")
 	b.WriteString(renderHintsFit(m.theme, m.width, hints...))
 
+	if m.launcher.active {
+		return m.launcher.view(m.theme, m.width, m.height)
+	}
 	return b.String()
 }
 
@@ -486,4 +532,70 @@ func (m accountModel) doRename() tea.Cmd {
 		}
 		return accountRenamedMsg{oldKey: oldKey, newKey: newKey}
 	}
+}
+
+// accountFolderPath resolves <global.folder>/<accountKey>. Launch helpers
+// need the folder to exist before shelling out; callers check os.Stat before
+// dispatching.
+func (m accountModel) accountFolderPath() string {
+	globalFolder := config.ExpandTilde(m.cfg.Global.Folder)
+	return filepath.Join(globalFolder, m.selectedKey)
+}
+
+// openAccountLauncher activates the overlay (bound to capital O) scoped to
+// the account's parent folder. No-op with a hint when the folder is missing
+// or the config has nothing to launch.
+func (m accountModel) openAccountLauncher() (accountModel, tea.Cmd) {
+	if !m.launcher.hasAny() {
+		m.errMsg = "No editors, terminals, or AI harnesses are configured."
+		m.statusMsg = ""
+		return m, nil
+	}
+	path := m.accountFolderPath()
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		m.errMsg = "Account folder does not exist: " + path
+		m.statusMsg = ""
+		return m, nil
+	}
+	m.launcher = m.launcher.activate(path)
+	m.statusMsg = ""
+	m.errMsg = ""
+	return m, nil
+}
+
+// launchAccountTerminal / launchAccountHarness wire the t / a keys on the
+// detail screen to the first entry of each category, scoped to the
+// account's parent folder. Editor default is intentionally not bound to a
+// single key here — lowercase e is the existing "edit account" shortcut;
+// users reach editors via the capital-O launcher.
+func (m accountModel) launchAccountTerminal() (accountModel, tea.Cmd) {
+	terms := m.cfg.Global.Terminals
+	if len(terms) == 0 {
+		return m, nil
+	}
+	path := m.accountFolderPath()
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		m.errMsg = "Account folder does not exist: " + path
+		m.statusMsg = ""
+		return m, nil
+	}
+	m.statusMsg = ""
+	m.errMsg = ""
+	return m, launchTerminalCmd(path, terms[0])
+}
+
+func (m accountModel) launchAccountHarness() (accountModel, tea.Cmd) {
+	harnesses := m.cfg.Global.AIHarnesses
+	if len(harnesses) == 0 {
+		return m, nil
+	}
+	path := m.accountFolderPath()
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		m.errMsg = "Account folder does not exist: " + path
+		m.statusMsg = ""
+		return m, nil
+	}
+	m.statusMsg = ""
+	m.errMsg = ""
+	return m, launchAIHarnessCmd(path, harnesses[0], m.cfg.Global.Terminals)
 }

--- a/cmd/cli/tui/screen_account_test.go
+++ b/cmd/cli/tui/screen_account_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/LuisPalacios/gitbox/pkg/config"
 )
 
 func TestAccount_Render(t *testing.T) {
@@ -106,6 +108,100 @@ func TestAccount_OpenFolder_SuccessSetsStatus(t *testing.T) {
 
 	if strings.Contains(m.account.errMsg, "does not exist") {
 		t.Errorf("folder exists but errMsg says it doesn't: %q", m.account.errMsg)
+	}
+}
+
+func TestAccount_LowercaseO_StillOpensFolder(t *testing.T) {
+	// Regression guard for the `o` / `O` split: lowercase o must remain
+	// bound to "open folder" even after the launcher work, preserving the
+	// existing muscle memory from #39.
+	gitFolder := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(gitFolder, "github-alice"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := newDummyConfig(t, gitFolder)
+	cfg.Global.Terminals = []config.TerminalEntry{{Name: "Git Bash", Command: "/bin/wt"}}
+	cfg.Global.AIHarnesses = []config.AIHarnessEntry{{Name: "Claude", Command: "/bin/claude"}}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{screen: screenAccount, accountKey: "github-alice"})
+	m = sendKey(m, "o")
+
+	if m.account.launcher.active {
+		t.Error("lowercase 'o' activated launcher overlay; it must stay bound to open-folder")
+	}
+}
+
+func TestAccount_CapitalO_OpensLauncher(t *testing.T) {
+	// Capital O is the new launcher key on the account screen. Folder must
+	// exist so the guard doesn't bail before the overlay activates.
+	gitFolder := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(gitFolder, "github-alice"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := newDummyConfig(t, gitFolder)
+	cfg.Global.Terminals = []config.TerminalEntry{{Name: "Git Bash", Command: "/bin/wt"}}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{screen: screenAccount, accountKey: "github-alice"})
+	m = sendKey(m, "O")
+
+	if !m.account.launcher.active {
+		t.Fatal("capital 'O' did not activate launcher overlay")
+	}
+
+	// Overlay path should be <gitFolder>/github-alice.
+	wantPath := filepath.Join(gitFolder, "github-alice")
+	if m.account.launcher.path != wantPath {
+		t.Errorf("launcher path = %q, want %q", m.account.launcher.path, wantPath)
+	}
+
+	// Esc closes without dispatching a command.
+	m = sendKey(m, "esc")
+	if m.account.launcher.active {
+		t.Error("esc did not close the launcher overlay")
+	}
+}
+
+func TestAccount_CapitalO_GuardsMissingFolder(t *testing.T) {
+	// When <global.folder>/<accountKey> doesn't exist, the overlay must
+	// refuse with a clear hint rather than activate and then dispatch
+	// launch commands that would fail against a nonexistent working dir.
+	cfg := newDummyConfig(t, filepath.Join(t.TempDir(), "never-created"))
+	cfg.Global.Terminals = []config.TerminalEntry{{Name: "Git Bash", Command: "/bin/wt"}}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{screen: screenAccount, accountKey: "github-alice"})
+	m = sendKey(m, "O")
+
+	if m.account.launcher.active {
+		t.Error("launcher activated despite missing account folder")
+	}
+	if !strings.Contains(m.account.errMsg, "does not exist") {
+		t.Errorf("expected guard errMsg, got %q", m.account.errMsg)
+	}
+}
+
+func TestAccount_Lowercase_e_StillOpensEditForm(t *testing.T) {
+	// Regression guard: adding launcher keys must not steal lowercase `e`
+	// from the existing edit-form shortcut.
+	cfg := newDummyConfig(t, "/tmp/test-git")
+	cfg.Global.Editors = []config.EditorEntry{{Name: "VS Code", Command: "/bin/code"}}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{screen: screenAccount, accountKey: "github-alice"})
+	m = sendKey(m, "e")
+
+	if m.account.view != accountViewEdit {
+		t.Errorf("lowercase 'e' did not open edit form; view = %d", m.account.view)
 	}
 }
 

--- a/cmd/cli/tui/screen_launcher.go
+++ b/cmd/cli/tui/screen_launcher.go
@@ -1,0 +1,285 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LuisPalacios/gitbox/cmd/cli/tui/styles"
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// launcherOverlay is a modal list of every configured launcher (editors,
+// terminals, AI harnesses). It's embedded in screens that want to offer a
+// "pick any launcher" entry point (screen_repos, screen_account) on top of
+// the direct-key defaults (t / e / a). Arrow keys move between selectable
+// items; group headers are non-selectable. Enter launches and closes, Esc
+// closes.
+type launcherOverlay struct {
+	active bool
+	path   string // working directory to launch in
+	items  []launcherItem
+	cursor int // index into items; always lands on a selectable entry
+}
+
+// launcherItemKind tags the row in the flat overlay list.
+type launcherItemKind int
+
+const (
+	launcherRowHeader launcherItemKind = iota
+	launcherRowEditor
+	launcherRowTerminal
+	launcherRowHarness
+)
+
+// launcherItem is one row in the overlay list. Headers use kind
+// launcherRowHeader and an empty payload; selectable rows have exactly one
+// of editor/term/harness set.
+type launcherItem struct {
+	kind  launcherItemKind
+	label string
+
+	editor  *config.EditorEntry
+	term    *config.TerminalEntry
+	harness *config.AIHarnessEntry
+}
+
+// newLauncherOverlay builds the overlay items from the current config.
+// Groups appear in the fixed order Terminals / Editors / AI Harnesses;
+// empty groups are omitted entirely (no header for zero entries).
+func newLauncherOverlay(cfg *config.Config) launcherOverlay {
+	lo := launcherOverlay{}
+	if cfg == nil {
+		return lo
+	}
+	g := cfg.Global
+
+	if len(g.Terminals) > 0 {
+		lo.items = append(lo.items, launcherItem{kind: launcherRowHeader, label: "Terminals"})
+		for i := range g.Terminals {
+			t := g.Terminals[i]
+			lo.items = append(lo.items, launcherItem{kind: launcherRowTerminal, label: t.Name, term: &t})
+		}
+	}
+	if len(g.Editors) > 0 {
+		lo.items = append(lo.items, launcherItem{kind: launcherRowHeader, label: "Editors"})
+		for i := range g.Editors {
+			e := g.Editors[i]
+			lo.items = append(lo.items, launcherItem{kind: launcherRowEditor, label: e.Name, editor: &e})
+		}
+	}
+	if len(g.AIHarnesses) > 0 {
+		lo.items = append(lo.items, launcherItem{kind: launcherRowHeader, label: "AI Harnesses"})
+		for i := range g.AIHarnesses {
+			h := g.AIHarnesses[i]
+			lo.items = append(lo.items, launcherItem{kind: launcherRowHarness, label: h.Name, harness: &h})
+		}
+	}
+
+	// Land the cursor on the first selectable row (skip initial header).
+	lo.cursor = lo.firstSelectable()
+	return lo
+}
+
+// hasAny reports whether the overlay has any selectable rows.
+func (lo launcherOverlay) hasAny() bool {
+	for _, it := range lo.items {
+		if it.kind != launcherRowHeader {
+			return true
+		}
+	}
+	return false
+}
+
+// activate turns the overlay on and sets the working directory launches will
+// target. Callers invoke this on the "open launcher" keypress (o / O).
+func (lo launcherOverlay) activate(path string) launcherOverlay {
+	lo.active = true
+	lo.path = path
+	if lo.cursor < 0 || lo.cursor >= len(lo.items) || lo.items[lo.cursor].kind == launcherRowHeader {
+		lo.cursor = lo.firstSelectable()
+	}
+	return lo
+}
+
+func (lo launcherOverlay) close() launcherOverlay {
+	lo.active = false
+	return lo
+}
+
+func (lo launcherOverlay) firstSelectable() int {
+	for i, it := range lo.items {
+		if it.kind != launcherRowHeader {
+			return i
+		}
+	}
+	return 0
+}
+
+func (lo launcherOverlay) lastSelectable() int {
+	last := 0
+	for i, it := range lo.items {
+		if it.kind != launcherRowHeader {
+			last = i
+		}
+	}
+	return last
+}
+
+// moveUp / moveDown navigate between selectable rows only, skipping headers.
+// At the edges the cursor stays put (no wraparound — follows existing TUI
+// list behavior).
+func (lo launcherOverlay) moveUp() launcherOverlay {
+	for i := lo.cursor - 1; i >= 0; i-- {
+		if lo.items[i].kind != launcherRowHeader {
+			lo.cursor = i
+			return lo
+		}
+	}
+	return lo
+}
+
+func (lo launcherOverlay) moveDown() launcherOverlay {
+	for i := lo.cursor + 1; i < len(lo.items); i++ {
+		if lo.items[i].kind != launcherRowHeader {
+			lo.cursor = i
+			return lo
+		}
+	}
+	return lo
+}
+
+// update handles key input while the overlay is active. It returns the new
+// overlay state, an optional tea.Cmd (a launch command when Enter is
+// pressed), and a bool indicating whether the key was consumed. Origin
+// screens should delegate to this before their own key handlers.
+func (lo launcherOverlay) update(msg tea.Msg, terminals []config.TerminalEntry) (launcherOverlay, tea.Cmd, bool) {
+	if !lo.active {
+		return lo, nil, false
+	}
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return lo, nil, false
+	}
+	switch {
+	case key.Matches(km, Keys.Back):
+		return lo.close(), nil, true
+	case key.Matches(km, Keys.Up):
+		return lo.moveUp(), nil, true
+	case key.Matches(km, Keys.Down):
+		return lo.moveDown(), nil, true
+	case key.Matches(km, Keys.Enter):
+		cmd := lo.launchCurrent(terminals)
+		return lo.close(), cmd, true
+	}
+	// Any other key is consumed so it doesn't leak to the origin screen
+	// while the overlay is showing.
+	return lo, nil, true
+}
+
+// launchCurrent returns the tea.Cmd that fires the selected launcher, or nil
+// if the cursor is on a non-selectable row (shouldn't happen in practice).
+func (lo launcherOverlay) launchCurrent(terminals []config.TerminalEntry) tea.Cmd {
+	if lo.cursor < 0 || lo.cursor >= len(lo.items) {
+		return nil
+	}
+	it := lo.items[lo.cursor]
+	switch it.kind {
+	case launcherRowEditor:
+		if it.editor == nil {
+			return nil
+		}
+		return launchEditorCmd(lo.path, it.editor.Command, it.editor.Name)
+	case launcherRowTerminal:
+		if it.term == nil {
+			return nil
+		}
+		return launchTerminalCmd(lo.path, *it.term)
+	case launcherRowHarness:
+		if it.harness == nil {
+			return nil
+		}
+		return launchAIHarnessCmd(lo.path, *it.harness, terminals)
+	}
+	return nil
+}
+
+// view renders the overlay as a centered box. Callers overlay this on top
+// of the origin screen's own View() output; lipgloss.Place handles centering
+// inside the available viewport.
+func (lo launcherOverlay) view(theme styles.Theme, width, height int) string {
+	if !lo.active {
+		return ""
+	}
+
+	title := theme.TextBold.Render("Open in…")
+	hint := theme.HelpDesc.Render("↑/↓ navigate · enter launch · esc cancel")
+
+	var body strings.Builder
+	body.WriteString(title)
+	body.WriteString("\n\n")
+
+	if !lo.hasAny() {
+		body.WriteString(theme.TextMuted.Render("No editors, terminals, or AI harnesses configured."))
+		body.WriteString("\n\n")
+		body.WriteString(hint)
+		return renderOverlayBox(theme, body.String(), width, height)
+	}
+
+	for i, it := range lo.items {
+		switch it.kind {
+		case launcherRowHeader:
+			if i > 0 {
+				body.WriteString("\n")
+			}
+			body.WriteString(theme.Heading.Render(it.label))
+			body.WriteString("\n")
+		default:
+			prefix := "  "
+			line := fmt.Sprintf("%s%s %s", prefix, iconFor(it.kind), it.label)
+			if i == lo.cursor {
+				body.WriteString(theme.SelectedRow.Render(line))
+			} else {
+				body.WriteString(theme.NormalRow.Render(line))
+			}
+			body.WriteString("\n")
+		}
+	}
+
+	body.WriteString("\n")
+	body.WriteString(hint)
+
+	return renderOverlayBox(theme, body.String(), width, height)
+}
+
+// iconFor picks a short glyph for each selectable row kind. Kept ASCII-safe
+// for terminals that don't render wide emoji well; the GUI uses the full
+// Unicode set from the issue spec.
+func iconFor(k launcherItemKind) string {
+	switch k {
+	case launcherRowEditor:
+		return "✎"
+	case launcherRowTerminal:
+		return ">_"
+	case launcherRowHarness:
+		return "🤖"
+	}
+	return " "
+}
+
+// renderOverlayBox wraps body in a bordered box and centers it in the
+// viewport. Width is capped so the box doesn't dominate on wide terminals.
+func renderOverlayBox(theme styles.Theme, body string, width, height int) string {
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(theme.Palette.BorderDefault)).
+		Padding(1, 2).
+		Render(body)
+
+	if width <= 0 || height <= 0 {
+		return box
+	}
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
+}

--- a/cmd/cli/tui/screen_launcher_test.go
+++ b/cmd/cli/tui/screen_launcher_test.go
@@ -1,0 +1,260 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LuisPalacios/gitbox/cmd/cli/tui/styles"
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fixtureConfigWithLaunchers returns a minimal config carrying two entries in
+// each launcher category so tests can exercise both "default" and "submenu"
+// paths without reaching for a fixture file.
+func fixtureConfigWithLaunchers() *config.Config {
+	return &config.Config{
+		Version: 2,
+		Global: config.GlobalConfig{
+			Folder: "/tmp/test-git",
+			Terminals: []config.TerminalEntry{
+				{Name: "Git Bash", Command: "/bin/wt", Args: []string{"--profile", "Git Bash", "-d", "{path}", "{command}"}},
+				{Name: "PowerShell", Command: "/bin/wt", Args: []string{"--profile", "PowerShell", "-d", "{path}", "{command}"}},
+			},
+			Editors: []config.EditorEntry{
+				{Name: "VS Code", Command: "/bin/code"},
+				{Name: "Cursor", Command: "/bin/cursor"},
+			},
+			AIHarnesses: []config.AIHarnessEntry{
+				{Name: "Claude Code", Command: "/bin/claude"},
+				{Name: "Codex", Command: "/bin/codex"},
+			},
+		},
+		Accounts: map[string]config.Account{},
+		Sources:  map[string]config.Source{},
+	}
+}
+
+func TestLauncher_BuildItemsFromConfig(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg)
+
+	// Expected layout: header+2 (terminals), header+2 (editors), header+2 (harnesses) = 9 rows.
+	if got, want := len(lo.items), 9; got != want {
+		t.Fatalf("items: got %d, want %d", got, want)
+	}
+
+	// Verify each group has exactly one header followed by its entries in the
+	// order defined in config (first-entry is the convention for defaults).
+	expected := []struct {
+		kind  launcherItemKind
+		label string
+	}{
+		{launcherRowHeader, "Terminals"},
+		{launcherRowTerminal, "Git Bash"},
+		{launcherRowTerminal, "PowerShell"},
+		{launcherRowHeader, "Editors"},
+		{launcherRowEditor, "VS Code"},
+		{launcherRowEditor, "Cursor"},
+		{launcherRowHeader, "AI Harnesses"},
+		{launcherRowHarness, "Claude Code"},
+		{launcherRowHarness, "Codex"},
+	}
+	for i, want := range expected {
+		got := lo.items[i]
+		if got.kind != want.kind || got.label != want.label {
+			t.Errorf("items[%d] = {%d, %q}, want {%d, %q}", i, got.kind, got.label, want.kind, want.label)
+		}
+	}
+
+	// Cursor lands on the first selectable row (Git Bash at index 1).
+	if lo.cursor != 1 {
+		t.Errorf("initial cursor = %d, want 1 (first selectable)", lo.cursor)
+	}
+}
+
+func TestLauncher_OmitsEmptyGroups(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	cfg.Global.Editors = nil // remove just the editor group
+
+	lo := newLauncherOverlay(cfg)
+
+	for _, it := range lo.items {
+		if it.kind == launcherRowHeader && it.label == "Editors" {
+			t.Error("empty editors group should not produce a header row")
+		}
+		if it.kind == launcherRowEditor {
+			t.Error("editor row in items despite empty config.Global.Editors")
+		}
+	}
+}
+
+func TestLauncher_NoLaunchers_NoSelectable(t *testing.T) {
+	cfg := &config.Config{Version: 2, Global: config.GlobalConfig{Folder: "/tmp"}}
+	lo := newLauncherOverlay(cfg)
+	if lo.hasAny() {
+		t.Error("hasAny() = true on empty config, want false")
+	}
+}
+
+func TestLauncher_NavigationSkipsHeaders(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg).activate("/tmp/test-git")
+
+	// Starting at index 1 (Git Bash). Press down → PowerShell (index 2).
+	// Press down again → should skip "Editors" header and land on VS Code (index 4).
+	lo2, _, handled := lo.update(tea.KeyMsg{Type: tea.KeyDown}, cfg.Global.Terminals)
+	if !handled {
+		t.Fatal("KeyDown not handled")
+	}
+	if lo2.cursor != 2 {
+		t.Errorf("after 1st down, cursor = %d, want 2", lo2.cursor)
+	}
+
+	lo3, _, _ := lo2.update(tea.KeyMsg{Type: tea.KeyDown}, cfg.Global.Terminals)
+	if lo3.cursor != 4 {
+		t.Errorf("after 2nd down (across header), cursor = %d, want 4", lo3.cursor)
+	}
+
+	// Up from VS Code: skip "Editors" header back to PowerShell (index 2).
+	lo4, _, _ := lo3.update(tea.KeyMsg{Type: tea.KeyUp}, cfg.Global.Terminals)
+	if lo4.cursor != 2 {
+		t.Errorf("after up (across header), cursor = %d, want 2", lo4.cursor)
+	}
+}
+
+func TestLauncher_EnterDispatchesLaunchCmd(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg).activate("/tmp/test-git")
+
+	// Cursor starts at Git Bash. Enter should return a non-nil tea.Cmd and
+	// close the overlay. We don't execute the cmd — that would fork a
+	// process — just verify the wiring.
+	lo2, cmd, handled := lo.update(tea.KeyMsg{Type: tea.KeyEnter}, cfg.Global.Terminals)
+	if !handled {
+		t.Fatal("Enter not handled")
+	}
+	if cmd == nil {
+		t.Fatal("Enter dispatched nil tea.Cmd (expected launch command)")
+	}
+	if lo2.active {
+		t.Error("overlay still active after Enter; should close")
+	}
+}
+
+func TestLauncher_EscClosesWithoutLaunch(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg).activate("/tmp/test-git")
+
+	lo2, cmd, handled := lo.update(tea.KeyMsg{Type: tea.KeyEsc}, cfg.Global.Terminals)
+	if !handled {
+		t.Fatal("Esc not handled")
+	}
+	if cmd != nil {
+		t.Error("Esc produced a tea.Cmd; expected nil (no launch)")
+	}
+	if lo2.active {
+		t.Error("overlay still active after Esc")
+	}
+}
+
+func TestLauncher_InactiveOverlayIgnoresKeys(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg) // not activated
+
+	_, _, handled := lo.update(tea.KeyMsg{Type: tea.KeyEnter}, cfg.Global.Terminals)
+	if handled {
+		t.Error("inactive overlay consumed Enter; it should delegate to origin screen")
+	}
+}
+
+func TestLauncher_ViewRendersGroupsAndHint(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg).activate("/tmp/test-git")
+	theme := styles.NewTheme(true)
+	out := lo.view(theme, 80, 24)
+
+	for _, want := range []string{"Open in…", "Terminals", "Editors", "AI Harnesses", "Git Bash", "VS Code", "Claude Code", "esc cancel"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q", want)
+		}
+	}
+}
+
+func TestLauncher_LaunchCurrentByKind(t *testing.T) {
+	cfg := fixtureConfigWithLaunchers()
+	lo := newLauncherOverlay(cfg).activate("/tmp")
+
+	// Cursor on Git Bash (terminal). launchCurrent should return a non-nil cmd.
+	if lo.launchCurrent(cfg.Global.Terminals) == nil {
+		t.Error("launchCurrent returned nil for a terminal row")
+	}
+
+	// Move to VS Code (editor at index 4).
+	lo.cursor = 4
+	if lo.launchCurrent(cfg.Global.Terminals) == nil {
+		t.Error("launchCurrent returned nil for an editor row")
+	}
+
+	// Move to Claude Code (harness at index 7).
+	lo.cursor = 7
+	if lo.launchCurrent(cfg.Global.Terminals) == nil {
+		t.Error("launchCurrent returned nil for a harness row")
+	}
+
+	// Harness without any configured terminal should still return a cmd,
+	// but running it would produce an actionable error. The cmd factory is
+	// responsible for the error, not launchCurrent; verify cmd != nil.
+	lo.cursor = 7
+	if lo.launchCurrent(nil) == nil {
+		t.Error("launchCurrent returned nil for a harness row with no terminals; expected cmd that surfaces the error")
+	}
+}
+
+func TestResolveTerminalArgs_PathSubstitution(t *testing.T) {
+	args := []string{"--profile", "Git Bash", "-d", "{path}"}
+	got := resolveTerminalArgs(args, "/repo", nil)
+	want := []string{"--profile", "Git Bash", "-d", "/repo"}
+	if !slicesEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveTerminalArgs_CommandSplice(t *testing.T) {
+	args := []string{"--profile", "X", "-d", "{path}", "{command}"}
+	harness := []string{"/bin/claude", "--flag"}
+	got := resolveTerminalArgs(args, "/repo", harness)
+	want := []string{"--profile", "X", "-d", "/repo", "/bin/claude", "--flag"}
+	if !slicesEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveTerminalArgs_AppendPathWhenNoToken(t *testing.T) {
+	// Legacy launcher patterns like `open -a Terminal <path>` have no {path}
+	// token; the resolver appends path as the last argv.
+	args := []string{"-a", "Terminal"}
+	got := resolveTerminalArgs(args, "/repo", nil)
+	want := []string{"-a", "Terminal", "/repo"}
+	if !slicesEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveTerminalArgs_EmptyArgsReturnsNil(t *testing.T) {
+	if resolveTerminalArgs(nil, "/repo", nil) != nil {
+		t.Error("empty args should return nil (terminal cmd.Dir covers it)")
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/cli/tui/screen_repos.go
+++ b/cmd/cli/tui/screen_repos.go
@@ -40,6 +40,7 @@ type reposModel struct {
 	cloneDoneCh    <-chan error
 	deleteStep     int // 0=inactive, 1=type name, 2=final confirm
 	deleteInput    textinput.Model
+	launcher       launcherOverlay
 }
 
 func newReposModel(cfg *config.Config, cfgPath, sourceKey, repoKey string, theme styles.Theme, w, h int) reposModel {
@@ -55,6 +56,7 @@ func newReposModel(cfg *config.Config, cfgPath, sourceKey, repoKey string, theme
 		sourceKey:   sourceKey,
 		repoKey:     repoKey,
 		deleteInput: ti,
+		launcher:    newLauncherOverlay(cfg),
 	}
 }
 
@@ -214,6 +216,15 @@ func (m reposModel) Init() tea.Cmd {
 }
 
 func (m reposModel) Update(msg tea.Msg) (reposModel, tea.Cmd) {
+	// Launcher overlay intercepts input when active; must run before the
+	// KeyMsg switch so t/e/a/o and other letters don't double-fire.
+	if lo, cmd, handled := m.launcher.update(msg, m.cfg.Global.Terminals); handled {
+		m.launcher = lo
+		m.resultMsg = ""
+		m.errMsg = ""
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		if m.busy {
@@ -318,7 +329,31 @@ func (m reposModel) Update(msg tea.Msg) (reposModel, tea.Cmd) {
 				m.errMsg = ""
 				return m, sweepRepoCmd(path, m.sourceKey, m.repoKey)
 			}
+
+		case msg.String() == "t":
+			// terminals[0] — skip if no terminal configured or repo not cloned.
+			return m.launchDefaultTerminal()
+
+		case msg.String() == "e":
+			// editors[0] — skip if no editor configured or repo not cloned.
+			return m.launchDefaultEditor()
+
+		case msg.String() == "a":
+			// ai_harnesses[0] — skip if none configured or repo not cloned.
+			return m.launchDefaultHarness()
+
+		case msg.String() == "o":
+			// Full launcher overlay listing every configured launcher.
+			return m.openLauncher()
 		}
+
+	case launchDoneMsg:
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+		} else {
+			m.resultMsg = "Opened in " + msg.target + "."
+		}
+		return m, nil
 
 	case cloneProgressMsg:
 		m.clonePhase = msg.phase
@@ -493,9 +528,107 @@ func (m reposModel) View() string {
 		actions = append(actions, "c clone")
 	} else {
 		actions = append(actions, "f fetch", "p pull", "s sweep")
+		if len(m.cfg.Global.Terminals) > 0 {
+			actions = append(actions, "t terminal")
+		}
+		if len(m.cfg.Global.Editors) > 0 {
+			actions = append(actions, "e editor")
+		}
+		if len(m.cfg.Global.AIHarnesses) > 0 {
+			actions = append(actions, "a AI")
+		}
+		if m.launcher.hasAny() {
+			actions = append(actions, "o open in…")
+		}
 	}
 	actions = append(actions, "b open browser", "D remove clone", "ESC back")
 	b.WriteString(renderHints(m.theme, actions...))
 
+	if m.launcher.active {
+		return m.launcher.view(m.theme, m.width, m.height)
+	}
 	return b.String()
 }
+
+// openLauncher activates the launcher overlay. No-op with a hint when the
+// repo folder does not exist on disk (launchers need a real working
+// directory) or when the config has no launchers at all.
+func (m reposModel) openLauncher() (reposModel, tea.Cmd) {
+	path := m.repoPath()
+	if !pathIsDir(path) {
+		m.errMsg = "Clone the repo first (c) — launchers need a local folder."
+		m.resultMsg = ""
+		return m, nil
+	}
+	if !m.launcher.hasAny() {
+		m.errMsg = "No editors, terminals, or AI harnesses are configured."
+		m.resultMsg = ""
+		return m, nil
+	}
+	m.launcher = m.launcher.activate(path)
+	m.resultMsg = ""
+	m.errMsg = ""
+	return m, nil
+}
+
+// launchDefaultTerminal / launchDefaultEditor / launchDefaultHarness wire
+// the t / e / a keys to the first entry of each category. Launching against
+// a missing folder would surface confusing shell errors, so each helper
+// silently no-ops when the category is empty and surfaces a guard message
+// when the repo isn't on disk.
+func (m reposModel) launchDefaultTerminal() (reposModel, tea.Cmd) {
+	terms := m.cfg.Global.Terminals
+	if len(terms) == 0 {
+		return m, nil
+	}
+	path := m.repoPath()
+	if !pathIsDir(path) {
+		m.errMsg = "Clone the repo first (c) before opening a terminal."
+		m.resultMsg = ""
+		return m, nil
+	}
+	m.resultMsg = ""
+	m.errMsg = ""
+	return m, launchTerminalCmd(path, terms[0])
+}
+
+func (m reposModel) launchDefaultEditor() (reposModel, tea.Cmd) {
+	editors := m.cfg.Global.Editors
+	if len(editors) == 0 {
+		return m, nil
+	}
+	path := m.repoPath()
+	if !pathIsDir(path) {
+		m.errMsg = "Clone the repo first (c) before opening an editor."
+		m.resultMsg = ""
+		return m, nil
+	}
+	m.resultMsg = ""
+	m.errMsg = ""
+	return m, launchEditorCmd(path, editors[0].Command, editors[0].Name)
+}
+
+func (m reposModel) launchDefaultHarness() (reposModel, tea.Cmd) {
+	harnesses := m.cfg.Global.AIHarnesses
+	if len(harnesses) == 0 {
+		return m, nil
+	}
+	path := m.repoPath()
+	if !pathIsDir(path) {
+		m.errMsg = "Clone the repo first (c) before opening an AI harness."
+		m.resultMsg = ""
+		return m, nil
+	}
+	m.resultMsg = ""
+	m.errMsg = ""
+	return m, launchAIHarnessCmd(path, harnesses[0], m.cfg.Global.Terminals)
+}
+
+// pathIsDir reports whether path refers to an existing directory. Small
+// helper to keep the launcher guards readable and consistent between the
+// repos and account screens.
+func pathIsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+

--- a/cmd/cli/tui/screen_repos_test.go
+++ b/cmd/cli/tui/screen_repos_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,6 +88,88 @@ func TestReposModel_OpenBrowser_SelfHosted(t *testing.T) {
 	m = sendMsg(m, openBrowserDoneMsg{err: nil})
 	if m.repos.resultMsg != "Opened in browser." {
 		t.Errorf("expected resultMsg 'Opened in browser.', got %q", m.repos.resultMsg)
+	}
+}
+
+func TestReposModel_LauncherKeys_NoOpWhenEmptyConfig(t *testing.T) {
+	// Default dummy config has no editors/terminals/harnesses. Pressing t/e/a
+	// should be no-op (no crash, no busy state, no cmd). This matches the
+	// hint bar rule — those letters aren't shown — but the handler must be
+	// robust to stray presses.
+	cfg := newDummyConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{
+		screen:    screenRepos,
+		sourceKey: "alice-repos",
+		repoKey:   "alice/hello-world",
+	})
+
+	for _, key := range []string{"t", "e", "a"} {
+		m = sendKey(m, key)
+		if m.repos.busy {
+			t.Errorf("key %q set busy state on empty-launcher config", key)
+		}
+		if m.repos.errMsg != "" {
+			t.Errorf("key %q set errMsg %q; expected empty (silent no-op)", key, m.repos.errMsg)
+		}
+	}
+}
+
+func TestReposModel_OpenLauncher_GuardsMissingFolder(t *testing.T) {
+	// When the repo folder doesn't exist on disk, `o` must refuse with a
+	// clear hint — editor/terminal launches need a real working directory.
+	cfg := newDummyConfig(t, filepath.Join(t.TempDir(), "never-created"))
+	cfg.Global.Terminals = []config.TerminalEntry{
+		{Name: "Git Bash", Command: "/bin/wt", Args: []string{"-d", "{path}"}},
+	}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{
+		screen:    screenRepos,
+		sourceKey: "alice-repos",
+		repoKey:   "alice/hello-world",
+	})
+
+	m = sendKey(m, "o")
+	if m.repos.launcher.active {
+		t.Error("launcher activated on missing folder; expected guard")
+	}
+	if !strings.Contains(m.repos.errMsg, "Clone the repo first") {
+		t.Errorf("expected guard errMsg, got %q", m.repos.errMsg)
+	}
+}
+
+func TestReposModel_OpenLauncher_ActivatesWhenFolderExists(t *testing.T) {
+	// Mirror for the happy path: the folder exists and launchers are
+	// configured, so `o` activates the overlay.
+	gitFolder := t.TempDir()
+	repoPath := filepath.Join(gitFolder, "alice-repos", "alice", "hello-world")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := newDummyConfig(t, gitFolder)
+	cfg.Global.Terminals = []config.TerminalEntry{{Name: "Git Bash", Command: "/bin/wt"}}
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m = sendMsg(m, switchScreenMsg{
+		screen:    screenRepos,
+		sourceKey: "alice-repos",
+		repoKey:   "alice/hello-world",
+	})
+
+	m = sendKey(m, "o")
+	if !m.repos.launcher.active {
+		t.Fatal("launcher did not activate despite valid folder + configured launcher")
+	}
+	if m.repos.launcher.path != repoPath {
+		t.Errorf("launcher path = %q, want %q", m.repos.launcher.path, repoPath)
 	}
 }
 

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import { statusColor, credColor, statusLabel, providerLabel, statusSymbol } from './lib/theme';
   import { WindowSetSize, WindowSetMinSize, WindowGetSize, WindowSetPosition, WindowGetPosition, BrowserOpenURL, Quit } from '../wailsjs/runtime/runtime';
   import type { RepoState, DiscoverResult, MirrorDTO, MirrorRepo, MirrorStatusResult, MirrorSetupResult, MirrorCredentialCheck, EditorInfo, TerminalInfo, AIHarnessInfo } from './lib/types';
+  import LauncherMenu from './lib/LauncherMenu.svelte';
 
   // ── View mode ──
   let viewMode: 'full' | 'compact' = 'full';
@@ -1997,18 +1998,18 @@
           <div class="action-menu-container source-header-kebab">
             <button class="btn-kebab" on:click|stopPropagation={() => toggleAccountMenu(accountKey)} title="Account actions">&#8942;</button>
             {#if actionMenuAccount === accountKey}
-              <div class="action-dropdown" transition:fade={{ duration: 80 }}>
-                <button class="action-item" on:click|stopPropagation={() => openAccountInBrowser(accountKey)}>Open in browser</button>
-                <button class="action-item" on:click|stopPropagation={() => openAccountInExplorer(accountKey)}>Open folder</button>
-                {#each configEditors as editor}
-                  <button class="action-item" on:click|stopPropagation={() => openAccountInApp(accountKey, editor.command)}>Open in {editor.name}</button>
-                {/each}
-                {#each configTerminals as terminal}
-                  <button class="action-item" on:click|stopPropagation={() => openAccountInTerminal(accountKey, terminal)}>Open in {terminal.name}</button>
-                {/each}
-                {#each configAIHarnesses as harness}
-                  <button class="action-item" on:click|stopPropagation={() => openAccountInAIHarness(accountKey, harness)}>Open in {harness.name}</button>
-                {/each}
+              <div transition:fade={{ duration: 80 }}>
+                <LauncherMenu
+                  kind="account"
+                  editors={configEditors}
+                  terminals={configTerminals}
+                  aiHarnesses={configAIHarnesses}
+                  onOpenBrowser={() => openAccountInBrowser(accountKey)}
+                  onOpenFolder={() => openAccountInExplorer(accountKey)}
+                  onOpenApp={(cmd) => openAccountInApp(accountKey, cmd)}
+                  onOpenTerminal={(t) => openAccountInTerminal(accountKey, t)}
+                  onOpenAIHarness={(h) => openAccountInAIHarness(accountKey, h)}
+                />
               </div>
             {/if}
           </div>
@@ -2066,19 +2067,19 @@
                 <div class="action-menu-container">
                   <button class="btn-kebab" on:click|stopPropagation={() => toggleActionMenu(repoKey)} title="Actions">&#8942;</button>
                   {#if actionMenuRepo === repoKey}
-                    <div class="action-dropdown" transition:fade={{ duration: 80 }}>
-                      <button class="action-item" on:click|stopPropagation={() => openRepoInBrowser(sourceKey, repoName)}>Open in browser</button>
-                      <button class="action-item" on:click|stopPropagation={() => openRepoInExplorer(repoKey)}>Open folder</button>
-                      <button class="action-item" on:click|stopPropagation={() => sweepBranches(sourceKey, repoName)}>Sweep branches</button>
-                      {#each configEditors as editor}
-                        <button class="action-item" on:click|stopPropagation={() => openRepoInApp(repoKey, editor.command)}>Open in {editor.name}</button>
-                      {/each}
-                      {#each configTerminals as terminal}
-                        <button class="action-item" on:click|stopPropagation={() => openRepoInTerminal(repoKey, terminal)}>Open in {terminal.name}</button>
-                      {/each}
-                      {#each configAIHarnesses as harness}
-                        <button class="action-item" on:click|stopPropagation={() => openRepoInAIHarness(repoKey, harness)}>Open in {harness.name}</button>
-                      {/each}
+                    <div transition:fade={{ duration: 80 }}>
+                      <LauncherMenu
+                        kind="repo"
+                        editors={configEditors}
+                        terminals={configTerminals}
+                        aiHarnesses={configAIHarnesses}
+                        onOpenBrowser={() => openRepoInBrowser(sourceKey, repoName)}
+                        onOpenFolder={() => openRepoInExplorer(repoKey)}
+                        onOpenApp={(cmd) => openRepoInApp(repoKey, cmd)}
+                        onOpenTerminal={(t) => openRepoInTerminal(repoKey, t)}
+                        onOpenAIHarness={(h) => openRepoInAIHarness(repoKey, h)}
+                        onSweep={() => sweepBranches(sourceKey, repoName)}
+                      />
                     </div>
                   {/if}
                 </div>

--- a/cmd/gui/frontend/src/lib/LauncherMenu.svelte
+++ b/cmd/gui/frontend/src/lib/LauncherMenu.svelte
@@ -142,7 +142,48 @@
 </div>
 
 <style>
-  .launcher-menu { min-width: 210px; }
+  /* Mirror the base dropdown/item styling from App.svelte — Svelte's scoped
+     styles don't cross component boundaries, so without these duplicates the
+     menu renders as flow-layout pill buttons. Keep these values in sync with
+     .action-dropdown / .action-item in App.svelte. */
+  .action-dropdown {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 4px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    min-width: 160px;
+    z-index: 100;
+    overflow: hidden;
+  }
+
+  .action-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 8px 14px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    text-align: left;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.1s;
+    white-space: nowrap;
+  }
+
+  .action-item:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  /* Launcher-specific layout additions. */
+  .launcher-menu {
+    min-width: 220px;
+  }
 
   .lm-sep {
     border: 0;
@@ -154,8 +195,9 @@
     display: inline-block;
     width: 18px;
     text-align: center;
-    margin-right: 8px;
+    margin-right: 10px;
     color: var(--text-dim);
+    flex: 0 0 auto;
   }
 
   .lm-icon-mono {
@@ -165,14 +207,11 @@
   }
 
   .lm-arrow {
-    float: right;
+    margin-left: auto;
+    padding-left: 10px;
     color: var(--text-dim);
     font-size: 10px;
-    line-height: 1.3em;
-  }
-
-  .lm-submenu-trigger {
-    padding-right: 14px;
+    flex: 0 0 auto;
   }
 
   .lm-active {
@@ -180,7 +219,15 @@
     color: var(--text-primary);
   }
 
-  .lm-sub-container { position: relative; }
+  .lm-sub-container {
+    position: relative;
+  }
+
+  /* Overflow has to release for submenus to escape the parent dropdown —
+     action-dropdown above uses overflow: hidden which otherwise clips them. */
+  .launcher-menu {
+    overflow: visible;
+  }
 
   /* Default (repo-row kebab): parent menu is pinned right: 0 so it extends
      to the left of the kebab. Open the submenu further left so it stays on
@@ -190,8 +237,8 @@
     top: -4px;
     right: 100%;
     margin-right: 2px;
-    z-index: 101;
     min-width: 180px;
+    z-index: 101;
   }
 
   /* Account-header kebab: parent menu is pinned left: 0 (see

--- a/cmd/gui/frontend/src/lib/LauncherMenu.svelte
+++ b/cmd/gui/frontend/src/lib/LauncherMenu.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  // LauncherMenu — shared action menu used by the repo-row kebab and the
+  // account-header kebab in full view. Renders a top section with the most-
+  // used launchers (editors[0], terminals[0], ai_harnesses[0]) and a submenu
+  // section for the rest of each category. Handlers are passed in as props so
+  // this component stays dumb and has no bridge dependency.
+  //
+  // Visual layout (both repo and account kebabs):
+  //   browser
+  //   folder
+  //   ─ separator ─ (only if any default is shown)
+  //   terminals[0]                        (hidden if terminals empty)
+  //   editors[0]                          (hidden if editors empty)
+  //   ai_harnesses[0]                     (hidden if harnesses empty)
+  //   ─ separator ─ (only if any submenu is shown)
+  //   Terminals ▸                         (hidden if <2 terminals)
+  //   Editors ▸                           (hidden if <2 editors)
+  //   AI Harnesses ▸                      (hidden if <2 harnesses)
+  //   ─ separator ─ (repo kebab only, when onSweep is provided)
+  //   Sweep branches                      (repo kebab only)
+
+  import type { EditorInfo, TerminalInfo, AIHarnessInfo } from './types';
+
+  export let kind: 'repo' | 'account' = 'repo';
+  export let editors: EditorInfo[] = [];
+  export let terminals: TerminalInfo[] = [];
+  export let aiHarnesses: AIHarnessInfo[] = [];
+
+  export let onOpenBrowser: () => void;
+  export let onOpenFolder: () => void;
+  export let onOpenApp: (command: string) => void;
+  export let onOpenTerminal: (terminal: TerminalInfo) => void;
+  export let onOpenAIHarness: (harness: AIHarnessInfo) => void;
+  export let onSweep: (() => void) | null = null;
+
+  type Sub = 'terminals' | 'editors' | 'ai' | null;
+  let openSubmenu: Sub = null;
+
+  function toggleSub(name: Exclude<Sub, null>) {
+    openSubmenu = openSubmenu === name ? null : name;
+  }
+
+  $: showTerminalDefault = terminals.length >= 1;
+  $: showEditorDefault = editors.length >= 1;
+  $: showHarnessDefault = aiHarnesses.length >= 1;
+  $: showTerminalsSub = terminals.length >= 2;
+  $: showEditorsSub = editors.length >= 2;
+  $: showHarnessSub = aiHarnesses.length >= 2;
+  $: hasDefaultsSection = showTerminalDefault || showEditorDefault || showHarnessDefault;
+  $: hasSubsSection = showTerminalsSub || showEditorsSub || showHarnessSub;
+  $: hasSweepSection = kind === 'repo' && !!onSweep;
+</script>
+
+<div class="action-dropdown launcher-menu">
+  <button class="action-item" on:click|stopPropagation={onOpenBrowser}>
+    <span class="lm-icon">&#127760;</span> Open in browser
+  </button>
+  <button class="action-item" on:click|stopPropagation={onOpenFolder}>
+    <span class="lm-icon">&#128193;</span> Open folder
+  </button>
+
+  {#if hasDefaultsSection}
+    <hr class="lm-sep" />
+    {#if showTerminalDefault}
+      <button class="action-item" on:click|stopPropagation={() => onOpenTerminal(terminals[0])} title="Open in {terminals[0].name}">
+        <span class="lm-icon lm-icon-mono">&gt;_</span> Open in {terminals[0].name}
+      </button>
+    {/if}
+    {#if showEditorDefault}
+      <button class="action-item" on:click|stopPropagation={() => onOpenApp(editors[0].command)} title="Open in {editors[0].name}">
+        <span class="lm-icon">&#9998;</span> Open in {editors[0].name}
+      </button>
+    {/if}
+    {#if showHarnessDefault}
+      <button class="action-item" on:click|stopPropagation={() => onOpenAIHarness(aiHarnesses[0])} title="Open in {aiHarnesses[0].name}">
+        <span class="lm-icon">&#129302;</span> Open in {aiHarnesses[0].name}
+      </button>
+    {/if}
+  {/if}
+
+  {#if hasSubsSection}
+    <hr class="lm-sep" />
+    {#if showTerminalsSub}
+      <div class="lm-sub-container">
+        <button class="action-item lm-submenu-trigger" class:lm-active={openSubmenu === 'terminals'} on:click|stopPropagation={() => toggleSub('terminals')}>
+          <span class="lm-icon lm-icon-mono">&gt;_</span> Terminals
+          <span class="lm-arrow">&#9654;</span>
+        </button>
+        {#if openSubmenu === 'terminals'}
+          <div class="action-dropdown launcher-submenu">
+            {#each terminals as terminal}
+              <button class="action-item" on:click|stopPropagation={() => onOpenTerminal(terminal)}>
+                <span class="lm-icon lm-icon-mono">&gt;_</span> {terminal.name}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+    {#if showEditorsSub}
+      <div class="lm-sub-container">
+        <button class="action-item lm-submenu-trigger" class:lm-active={openSubmenu === 'editors'} on:click|stopPropagation={() => toggleSub('editors')}>
+          <span class="lm-icon">&#9998;</span> Editors
+          <span class="lm-arrow">&#9654;</span>
+        </button>
+        {#if openSubmenu === 'editors'}
+          <div class="action-dropdown launcher-submenu">
+            {#each editors as editor}
+              <button class="action-item" on:click|stopPropagation={() => onOpenApp(editor.command)}>
+                <span class="lm-icon">&#9998;</span> {editor.name}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+    {#if showHarnessSub}
+      <div class="lm-sub-container">
+        <button class="action-item lm-submenu-trigger" class:lm-active={openSubmenu === 'ai'} on:click|stopPropagation={() => toggleSub('ai')}>
+          <span class="lm-icon">&#129302;</span> AI Harnesses
+          <span class="lm-arrow">&#9654;</span>
+        </button>
+        {#if openSubmenu === 'ai'}
+          <div class="action-dropdown launcher-submenu">
+            {#each aiHarnesses as harness}
+              <button class="action-item" on:click|stopPropagation={() => onOpenAIHarness(harness)}>
+                <span class="lm-icon">&#129302;</span> {harness.name}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+
+  {#if hasSweepSection}
+    <hr class="lm-sep" />
+    <button class="action-item" on:click|stopPropagation={onSweep}>
+      <span class="lm-icon">&#129529;</span> Sweep branches
+    </button>
+  {/if}
+</div>
+
+<style>
+  .launcher-menu { min-width: 210px; }
+
+  .lm-sep {
+    border: 0;
+    border-top: 1px solid var(--border);
+    margin: 4px 0;
+  }
+
+  .lm-icon {
+    display: inline-block;
+    width: 18px;
+    text-align: center;
+    margin-right: 8px;
+    color: var(--text-dim);
+  }
+
+  .lm-icon-mono {
+    font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .lm-arrow {
+    float: right;
+    color: var(--text-dim);
+    font-size: 10px;
+    line-height: 1.3em;
+  }
+
+  .lm-submenu-trigger {
+    padding-right: 14px;
+  }
+
+  .lm-active {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .lm-sub-container { position: relative; }
+
+  /* Default (repo-row kebab): parent menu is pinned right: 0 so it extends
+     to the left of the kebab. Open the submenu further left so it stays on
+     screen. */
+  .launcher-submenu {
+    position: absolute;
+    top: -4px;
+    right: 100%;
+    margin-right: 2px;
+    z-index: 101;
+    min-width: 180px;
+  }
+
+  /* Account-header kebab: parent menu is pinned left: 0 (see
+     .source-header-kebab .action-dropdown in App.svelte) so it extends to
+     the right. Flip the submenu to also open right so it stays on screen. */
+  :global(.source-header-kebab) .launcher-submenu {
+    right: auto;
+    left: 100%;
+    margin-right: 0;
+    margin-left: 2px;
+  }
+</style>

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -253,24 +253,27 @@ Click the **gear icon** to open the settings panel:
 
 ### Clone actions
 
-Each cloned repo row has a **kebab menu (⋮)** on the right side. Click it to see:
+Each cloned repo row has a **kebab menu (⋮)** on the right side. The menu is split into three sections so the items you use most aren't buried behind scrolling:
 
-- **Open in browser** — opens the repository's remote web page (GitHub, GitLab, etc.) in the default browser
-- **Open folder** — opens the clone directory in the OS file manager (Explorer, Finder, or your Linux file manager)
-- **Sweep branches** — finds and deletes stale local branches (gone, merged, or squash-merged). Shows a confirmation dialog with the list of branches before deleting anything
-- **Open in \<editor\>** — opens the clone folder in a detected code editor (VS Code, Cursor, Zed, etc.)
-- **Open in \<terminal\>** — opens a new shell window in the clone folder using a detected terminal emulator (Windows Terminal, PowerShell 7/5, Git Bash, WSL, Command Prompt on Windows; Terminal, iTerm, Warp on macOS; gnome-terminal, Konsole, Kitty, Alacritty, Xfce Terminal, Terminator on Linux)
-- **Open in \<AI harness\>** — opens the clone folder inside the first configured terminal and spawns an AI CLI harness (Claude Code, Codex, Gemini, Aider, Cursor Agent, OpenCode) in it. See [AI harness actions](#ai-harness-actions) below
+1. **Always visible** — `🌐 Open in browser` and `📁 Open folder`.
+2. **Defaults** — one entry per category, using the first config entry as the default: `>_ Open in <terminals[0]>`, `✎ Open in <editors[0]>`, `🤖 Open in <ai_harnesses[0]>`. An entry is hidden when that category has zero configured items.
+3. **Submenus** — `Terminals ▸`, `Editors ▸`, `AI Harnesses ▸`. Each submenu only appears when the category has **two or more** entries — with just one, the default already covers it. Click the submenu to expand (not hover), click another submenu to switch, click outside or pick an item to close everything.
+
+Below the submenus:
+
+- **🧹 Sweep branches** — finds and deletes stale local branches (gone, merged, or squash-merged). Shows a confirmation dialog with the list of branches before deleting anything.
+
+To change which terminal/editor/harness appears as the top-level default, reorder the array in `gitbox.json` — the first entry is always the default. No separate flag required.
+
+The list of detected terminals covers Windows Terminal, PowerShell 7/5, Git Bash, WSL, and Command Prompt on Windows; Terminal, iTerm, and Warp on macOS; gnome-terminal, Konsole, Kitty, Alacritty, Xfce Terminal, and Terminator on Linux. Editors cover VS Code, Cursor, Zed, and anything else discoverable on `PATH`. AI harnesses (Claude Code, Codex, Gemini, Aider, Cursor Agent, OpenCode) run inside the first configured terminal — see [AI harness actions](#ai-harness-actions) below.
 
 ### Account actions
 
-Each source group in the repo list has a **kebab menu (⋮)** on the right side of its header (the account title above the list of clones). The account kebab exposes actions scoped to the account's parent folder (`<global.folder>/<account-key>`) rather than any single clone:
+Each source group in the repo list has a **kebab menu (⋮)** on the right side of its header (the account title above the list of clones). The account kebab uses the **same structure and icons** as the repo-row kebab — top-level defaults, per-category submenus, same hide rules — scoped to the account's parent folder (`<global.folder>/<account-key>`) rather than a single clone:
 
-- **Open in browser** — opens the provider profile/org page for the account (e.g. `https://github.com/<username>`, the GitLab group page, the Gitea/Forgejo user page)
-- **Open folder** — opens the account's parent folder in the OS file manager. The folder is the natural workspace root for cross-repo greps, multi-repo edits, or shell loops. If the folder doesn't exist yet (nothing cloned under that account), the action errors silently — clone at least one repo first.
-- **Open in \<editor\>** — opens the parent folder in each configured editor from `global.editors`
-- **Open in \<terminal\>** — opens a terminal in the parent folder using each configured entry from `global.terminals`
-- **Open in \<AI harness\>** — spawns an AI CLI harness inside the account's parent folder, using `global.terminals[0]` as the host terminal. See [AI harness actions](#ai-harness-actions) below
+- **🌐 Open in browser** — opens the provider profile/org page for the account (e.g. `https://github.com/<username>`, the GitLab group page, the Gitea/Forgejo user page).
+- **📁 Open folder** — opens the account's parent folder in the OS file manager. The folder is the natural workspace root for cross-repo greps, multi-repo edits, or shell loops. If the folder doesn't exist yet (nothing cloned under that account), the action errors silently — clone at least one repo first.
+- **>_ Open in \<terminal\>**, **✎ Open in \<editor\>**, **🤖 Open in \<AI harness\>** — same default-first entries as the repo kebab, plus the category submenus when you have multiple options configured. Sweep branches is dropped here — it's meaningful only on a specific clone.
 
 In compact view, hovering an account pill reveals the same folder / editor / terminal / AI harness shortcuts as small icons on the right side, matching the compact repo-row behavior.
 

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Gitbox does not implement any Git protocol or plumbing logic. It acts as an orch
 - **Safe pulling** — fast-forward-only pulls; dirty or conflicted repos are never touched
 - **Cross-provider mirroring** — push or pull mirrors between providers for backups (e.g., Forgejo → GitHub)
 - **Credential switching** — change auth types (GCM ↔ SSH ↔ Token) with automatic cleanup
+- **One-click clone actions** — every repo row (and every account header) has a kebab menu to open the clone in a browser, file manager, terminal, editor, or AI CLI harness (Claude Code, Codex, Gemini, …). Each category collapses to a single default entry plus a submenu when you have more than one configured. The TUI exposes the same actions via `t` / `e` / `a` keys and an `o` launcher modal.
 
 It support four providers. GitHub, GitLab, Gitea/Forgejo, and Bitbucket all work for discovery, cloning, and repo creation. Push mirrors work natively on Gitea/Forgejo and GitLab; pull mirrors work on Gitea/Forgejo. For GitHub and Bitbucket mirror setup, gitbox generates step-by-step guides.
 


### PR DESCRIPTION
Closes #24

## What changed

- Extracted `cmd/gui/frontend/src/lib/LauncherMenu.svelte` — one component renders both the repo-row kebab and the account-header kebab, so visual and behavioural parity is a compile-time guarantee rather than a drift-prone copy.
- Restructured the full-view kebab into three sections: always-visible (browser, folder), per-category default using `terminals[0]` / `editors[0]` / `ai_harnesses[0]`, and per-category submenus that only appear when a category has two or more entries. Sweep branches stays as a repo-only entry below the submenus. Submenu positioning flips based on which side the parent menu is pinned to (left for repo-row kebab, right for account-header kebab).
- Fixed Svelte scoped-styles boundary: duplicated the base `.action-dropdown` / `.action-item` rules inside the new component so the menu renders as a vertical dropdown instead of flow-layout pill buttons.
- TUI: added direct-key shortcuts on both the repo and account detail screens (`t` = terminals[0], `e` = editors[0] on repo only, `a` = ai_harnesses[0]), plus an `o` / `O` launcher modal listing every configured launcher grouped by category. Lowercase `e` / `o` on the account screen stay bound to the existing edit-form / open-folder actions; the capital `O` launcher covers editor access there without breaking muscle memory.
- New shared launcher helpers in `cmd/cli/tui/launchers.go` (argv-level `{path}` / `{command}` resolver, minimal duplication of the GUI's logic since the TUI already owns a console and doesn't need the Windows `cmd.exe /C start` wrapper).
- Docs: README "What it does" gains a one-line hook for the clone/account launcher actions. `docs/gui-guide.md` Clone + Account actions sections rewritten to describe the default-then-submenu layout, submenu hide rules, and click-not-hover behaviour.

## Test plan

- [ ] GUI full view: repo-row ⋮ renders as a vertical dropdown with sections — browser/folder, default launchers, submenus (appear only when ≥2 entries in the category), Sweep branches at the bottom. Default-launcher entries hide cleanly when a category has zero entries.
- [ ] GUI full view: `Terminals ▸` / `Editors ▸` / `AI Harnesses ▸` open on click, flip side based on kebab position, close on outside-click or action fire.
- [ ] GUI full view: account-header ⋮ uses the same layout, with no Sweep entry.
- [ ] GUI compact view unchanged — folder / editor / terminal / harness icons still launch their defaults.
- [ ] TUI repo detail (cloned repo): `t` / `e` / `a` launch the first configured entry of each category, `o` opens the launcher modal (arrow-keys, Enter, Esc).
- [ ] TUI account detail: lowercase `e` still opens the edit form, lowercase `o` still opens the account folder, capital `O` opens the launcher. `t` / `a` launch the first terminal / harness against the account's parent folder.
- [ ] Empty-category keys are silent no-ops (no crash, no error) when pressed on a config with nothing in that category.
- [ ] `go vet ./...`, `go test -short ./...`, and a full wails build on Windows all pass.