### PR TITLE
GUI: smarter kebab placement, cleaner compact view (#45)

### DIFF
--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1710,18 +1710,6 @@
             {/if}
           </span>
         </div>
-        <span class="compact-actions-overlay compact-acct-actions">
-          <button class="compact-action-btn" on:click|stopPropagation={() => openAccountInExplorer(key)} title="Open folder">&#128193;</button>
-          {#if configEditors.length > 0}
-            <button class="compact-action-btn" on:click|stopPropagation={() => openAccountInApp(key, configEditors[0].command)} title="Open in {configEditors[0].name}">&#9998;</button>
-          {/if}
-          {#if configTerminals.length > 0}
-            <button class="compact-action-btn" on:click|stopPropagation={() => openAccountInTerminal(key, configTerminals[0])} title="Open in {configTerminals[0].name}">&gt;_</button>
-          {/if}
-          {#if configAIHarnesses.length > 0}
-            <button class="compact-action-btn" on:click|stopPropagation={() => openAccountInAIHarness(key, configAIHarnesses[0])} title="Open in {configAIHarnesses[0].name}">&#129302;</button>
-          {/if}
-        </span>
         <span class="compact-chevron">{compactExpanded[key] ? '▾' : '▸'}</span>
       </button>
 
@@ -1735,8 +1723,6 @@
               <span class="compact-repo-name">{repoName.includes('/') ? repoName.split('/').pop() : repoName}</span>
               {#if state.branch === '(detached)'}
                 <span class="compact-badge" style="color: {sc('error')}">detached</span>
-              {:else if state.branch && !state.isDefault}
-                <span class="compact-badge branch-badge">{state.branch}</span>
               {/if}
               {#if state.status === 'behind'}
                 <span class="compact-badge" style="color: {sc('behind')}">{state.behind} behind</span>
@@ -1744,20 +1730,6 @@
                 <span class="compact-badge" style="color: {sc('dirty')}">{state.modified} changed</span>
               {:else if state.status === 'ahead'}
                 <span class="compact-badge" style="color: {sc('ahead')}">{state.ahead} ahead</span>
-              {/if}
-              {#if state.status !== 'not cloned'}
-                <span class="compact-actions-overlay">
-                  <button class="compact-action-btn" on:click|stopPropagation={() => openRepoInBrowser(key, repoName)} title="Open in browser">&#8599;</button>
-                  {#if configEditors.length > 0}
-                    <button class="compact-action-btn" on:click|stopPropagation={() => openRepoInApp(repoKey, configEditors[0].command)} title="Open in {configEditors[0].name}">&#9998;</button>
-                  {/if}
-                  {#if configTerminals.length > 0}
-                    <button class="compact-action-btn" on:click|stopPropagation={() => openRepoInTerminal(repoKey, configTerminals[0])} title="Open in {configTerminals[0].name}">&gt;_</button>
-                  {/if}
-                  {#if configAIHarnesses.length > 0}
-                    <button class="compact-action-btn" on:click|stopPropagation={() => openRepoInAIHarness(repoKey, configAIHarnesses[0])} title="Open in {configAIHarnesses[0].name}">&#129302;</button>
-                  {/if}
-                </span>
               {/if}
             </div>
           {/each}
@@ -3195,6 +3167,7 @@
 
   :global([data-theme="dark"]) {
     --bg-base: #09090b; --bg-card: #18181b; --bg-hover: #27272a;
+    --bg-row-hover: #3f3f46;
     --border: #27272a; --border-hover: #3f3f46;
     --text-primary: #fafafa; --text-secondary: #b4b4bd; --text-muted: #8e8e99; --text-dim: #71717a;
     --text-repo: #e4e4e7;
@@ -3205,6 +3178,7 @@
   }
   :global([data-theme="light"]) {
     --bg-base: #fafafa; --bg-card: #ffffff; --bg-hover: #f4f4f5;
+    --bg-row-hover: #d4d4d8;
     --border: #e4e4e7; --border-hover: #d4d4d8;
     --text-primary: #18181b; --text-secondary: #52525b; --text-muted: #71717a; --text-dim: #a1a1aa;
     --text-repo: #27272a;
@@ -3371,7 +3345,7 @@
     display: flex; align-items: center; gap: 10px;
     padding: 8px 6px; border-radius: 6px; transition: background 0.1s;
   }
-  .repo-row:hover { background: var(--bg-card); }
+  .repo-row:hover { background: var(--bg-row-hover); }
 
   .dot { font-size: 14px; flex-shrink: 0; width: 18px; text-align: center; }
   .repo-name { font-size: 13px; color: var(--text-repo); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -3423,7 +3397,7 @@
 
   /* ── Repo detail panel ── */
   .repo-row-clickable { cursor: pointer; }
-  .repo-row-clickable:hover { background: var(--bg-card); }
+  .repo-row-clickable:hover { background: var(--bg-row-hover); }
   .repo-detail {
     margin: 0 0 2px 0; padding: 8px 16px 10px 30px;
     background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px;
@@ -3801,12 +3775,6 @@
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .compact-acct-stat { font-size: 9px; }
-  .compact-acct-actions {
-    position: static; background: transparent; padding: 0;
-    opacity: 0; transition: opacity 0.1s;
-    display: flex; align-items: center; gap: 2px; flex-shrink: 0;
-  }
-  .compact-acct:hover .compact-acct-actions { opacity: 1; }
   .compact-chevron {
     font-size: 10px;
     color: var(--text-dim);
@@ -3830,23 +3798,8 @@
     border-radius: 4px;
     transition: background 0.1s;
   }
-  .compact-row { position: relative; }
   .compact-row:hover { background: var(--bg-hover); }
   .compact-row-ok { opacity: 0.5; }
-  .compact-actions-overlay {
-    position: absolute; right: 2px; top: 0; bottom: 0;
-    display: flex; align-items: center; gap: 2px;
-    background: var(--bg-card); padding: 0 2px;
-    opacity: 0; transition: opacity 0.1s;
-  }
-  .compact-row:hover .compact-actions-overlay { opacity: 1; }
-  .compact-row:hover.compact-row-ok .compact-actions-overlay { opacity: 1; }
-  .compact-action-btn {
-    background: transparent; border: none; cursor: pointer;
-    font-size: 11px; padding: 1px 3px; border-radius: 3px;
-    color: var(--text-dim); line-height: 1; transition: color 0.1s;
-  }
-  .compact-action-btn:hover { color: var(--text-primary); }
   .compact-dot { font-size: 9px; flex-shrink: 0; width: 10px; text-align: center; }
   .compact-repo-name {
     flex: 1;

--- a/cmd/gui/frontend/src/lib/LauncherMenu.svelte
+++ b/cmd/gui/frontend/src/lib/LauncherMenu.svelte
@@ -19,6 +19,7 @@
   //   ─ separator ─ (repo kebab only, when onSweep is provided)
   //   Sweep branches                      (repo kebab only)
 
+  import { onMount, tick } from 'svelte';
   import type { EditorInfo, TerminalInfo, AIHarnessInfo } from './types';
 
   export let kind: 'repo' | 'account' = 'repo';
@@ -36,8 +37,139 @@
   type Sub = 'terminals' | 'editors' | 'ai' | null;
   let openSubmenu: Sub = null;
 
-  function toggleSub(name: Exclude<Sub, null>) {
+  // Root element of the dropdown, used to measure and flip/shift into view.
+  let rootEl: HTMLDivElement | undefined;
+  // Submenu element (only one is open at a time).
+  let subEl: HTMLDivElement | undefined;
+
+  const VIEWPORT_PADDING = 8;
+
+  function positionMenu(el: HTMLElement | undefined) {
+    if (!el) return;
+    // Reset any prior inline overrides so measurement reflects default CSS.
+    el.style.top = '';
+    el.style.bottom = '';
+    el.style.left = '';
+    el.style.right = '';
+    el.style.marginTop = '';
+    el.style.marginBottom = '';
+    el.style.transform = '';
+
+    const trigger = el.parentElement?.parentElement;
+    if (!trigger) return;
+    const triggerRect = trigger.getBoundingClientRect();
+    const vh = window.innerHeight;
+    const vw = window.innerWidth;
+
+    // Repo kebab rows share a vertical column of kebabs — one per row in
+    // the same group and the next. Slide the menu sideways off that column
+    // (always, whether we open below or flip up) so the user can click
+    // neighbouring kebabs without dismissing this menu first. Account-
+    // header kebabs stand alone and don't need the shift.
+    if (kind === 'repo') {
+      el.style.right = `${Math.round(triggerRect.width)}px`;
+    }
+
+    // Vertical flip: if the menu overflows the viewport below the trigger
+    // and more space exists above, anchor to the top edge of the trigger.
+    const rect = el.getBoundingClientRect();
+    const overflowsBelow = rect.bottom > vh - VIEWPORT_PADDING;
+    const spaceAbove = triggerRect.top;
+    const spaceBelow = vh - triggerRect.bottom;
+    const flipUp = overflowsBelow && spaceAbove > spaceBelow;
+    if (flipUp) {
+      el.style.top = 'auto';
+      el.style.bottom = '100%';
+      el.style.marginTop = '0';
+      el.style.marginBottom = '4px';
+    }
+
+    // Horizontal clamp: keep the menu inside the viewport with a transform.
+    const post = el.getBoundingClientRect();
+    let dx = 0;
+    if (post.right > vw - VIEWPORT_PADDING) {
+      dx = vw - VIEWPORT_PADDING - post.right;
+    } else if (post.left < VIEWPORT_PADDING) {
+      dx = VIEWPORT_PADDING - post.left;
+    }
+    if (dx !== 0) {
+      el.style.transform = `translateX(${Math.round(dx)}px)`;
+    }
+  }
+
+  function positionSubmenu(el: HTMLElement | undefined) {
+    if (!el) return;
+    el.style.top = '';
+    el.style.bottom = '';
+    el.style.left = '';
+    el.style.right = '';
+    el.style.marginLeft = '';
+    el.style.marginRight = '';
+    el.style.transform = '';
+
+    const vh = window.innerHeight;
+    const vw = window.innerWidth;
+
+    // The submenu is anchored to its own lm-sub-container (the parent
+    // menu item). Use the container's position to decide which side has
+    // more room. This is more reliable than "flip only if the default
+    // side overflows" because on narrow viewports both sides can overflow
+    // and we need to pick the larger one up front.
+    const container = el.parentElement;
+    const anchorRect = container ? container.getBoundingClientRect() : el.getBoundingClientRect();
+    const submenuWidth = el.offsetWidth;
+    const spaceLeft = anchorRect.left;
+    const spaceRight = vw - anchorRect.right;
+    const preferRight = spaceRight >= submenuWidth + VIEWPORT_PADDING
+      || (spaceRight > spaceLeft && spaceLeft < submenuWidth + VIEWPORT_PADDING);
+
+    if (preferRight) {
+      el.style.right = 'auto';
+      el.style.left = '100%';
+      el.style.marginRight = '0';
+      el.style.marginLeft = '2px';
+    } else {
+      el.style.left = 'auto';
+      el.style.right = '100%';
+      el.style.marginLeft = '0';
+      el.style.marginRight = '2px';
+    }
+
+    // Horizontal clamp: if neither side has full room, shift with a
+    // transform so the whole submenu stays on screen. May overlap the
+    // parent menu, but that's preferable to being clipped off-screen.
+    const rect = el.getBoundingClientRect();
+    let dx = 0;
+    if (rect.right > vw - VIEWPORT_PADDING) {
+      dx = vw - VIEWPORT_PADDING - rect.right;
+    } else if (rect.left < VIEWPORT_PADDING) {
+      dx = VIEWPORT_PADDING - rect.left;
+    }
+
+    // Vertical clamp: keep the submenu inside the viewport top and bottom.
+    let dy = 0;
+    if (rect.bottom > vh - VIEWPORT_PADDING) {
+      dy = vh - VIEWPORT_PADDING - rect.bottom;
+    } else if (rect.top < VIEWPORT_PADDING) {
+      dy = VIEWPORT_PADDING - rect.top;
+    }
+
+    if (dx !== 0 || dy !== 0) {
+      el.style.transform = `translate(${Math.round(dx)}px, ${Math.round(dy)}px)`;
+    }
+  }
+
+  onMount(async () => {
+    await tick();
+    positionMenu(rootEl);
+  });
+
+  async function toggleSub(name: Exclude<Sub, null>) {
     openSubmenu = openSubmenu === name ? null : name;
+    if (openSubmenu) {
+      await tick();
+      positionSubmenu(subEl);
+    }
   }
 
   $: showTerminalDefault = terminals.length >= 1;
@@ -51,7 +183,7 @@
   $: hasSweepSection = kind === 'repo' && !!onSweep;
 </script>
 
-<div class="action-dropdown launcher-menu">
+<div class="action-dropdown launcher-menu" bind:this={rootEl}>
   <button class="action-item" on:click|stopPropagation={onOpenBrowser}>
     <span class="lm-icon">&#127760;</span> Open in browser
   </button>
@@ -87,7 +219,7 @@
           <span class="lm-arrow">&#9654;</span>
         </button>
         {#if openSubmenu === 'terminals'}
-          <div class="action-dropdown launcher-submenu">
+          <div class="action-dropdown launcher-submenu" bind:this={subEl}>
             {#each terminals as terminal}
               <button class="action-item" on:click|stopPropagation={() => onOpenTerminal(terminal)}>
                 <span class="lm-icon lm-icon-mono">&gt;_</span> {terminal.name}
@@ -104,7 +236,7 @@
           <span class="lm-arrow">&#9654;</span>
         </button>
         {#if openSubmenu === 'editors'}
-          <div class="action-dropdown launcher-submenu">
+          <div class="action-dropdown launcher-submenu" bind:this={subEl}>
             {#each editors as editor}
               <button class="action-item" on:click|stopPropagation={() => onOpenApp(editor.command)}>
                 <span class="lm-icon">&#9998;</span> {editor.name}
@@ -121,7 +253,7 @@
           <span class="lm-arrow">&#9654;</span>
         </button>
         {#if openSubmenu === 'ai'}
-          <div class="action-dropdown launcher-submenu">
+          <div class="action-dropdown launcher-submenu" bind:this={subEl}>
             {#each aiHarnesses as harness}
               <button class="action-item" on:click|stopPropagation={() => onOpenAIHarness(harness)}>
                 <span class="lm-icon">&#129302;</span> {harness.name}
@@ -158,6 +290,11 @@
     min-width: 160px;
     z-index: 100;
     overflow: hidden;
+    /* Safety net: on very small viewports, scroll inside the menu instead
+       of clipping below the fold. The flip/shift logic above handles the
+       normal case; this only kicks in when no side has enough space. */
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
   }
 
   .action-item {


### PR DESCRIPTION
Closes #45

## What changed

- Compact view drops the hover overlay of action icons (overlapped repo names on narrow windows) and the non-default branch badge. `detached` state badge stays. Full-view kebab still exposes every action.
- Full-view kebab always sits off the kebab column (both when open below and when flipped above), so neighbouring kebabs stay clickable.
- Kebab flips above the trigger when bottom space is tight.
- Submenus now pick the side with more room up front, then clamp inside the viewport as a last resort on narrow windows; vertical clamp keeps them from falling off the bottom.
- `max-height + overflow-y` safety net so very small viewports show a scrollable menu instead of clipping.
- Full-view row hover uses a new `--bg-row-hover` token for clearer contrast against the base background.

Vanilla JS inside `LauncherMenu.svelte`, no new dependency.

## Test plan

- [ ] Compact view — no action icons appear on row hover; no non-default branch badge; `detached` badge still shown when applicable.
- [ ] Full view — row hover background clearly contrasted.
- [ ] Full view — open a kebab at the bottom of a group; menu flips above the trigger and shifts off the kebab column.
- [ ] Full view — open a kebab whose submenu would overflow on one side; submenu opens on the side with more room.
- [ ] Very narrow window — menu remains scrollable rather than clipped.
- [ ] Wide window — default below/right placement unchanged.