### PR TITLE
TUI: Workspaces tab, add flow, launcher submenu, multi-select

### DIFF
--- a/cmd/cli/tui/dashboard.go
+++ b/cmd/cli/tui/dashboard.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	neturl "net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"github.com/LuisPalacios/gitbox/pkg/identity"
 	"github.com/LuisPalacios/gitbox/pkg/mirror"
 	"github.com/LuisPalacios/gitbox/pkg/status"
+	"github.com/LuisPalacios/gitbox/pkg/workspace"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -26,6 +29,7 @@ type tabID int
 const (
 	tabAccounts tabID = iota
 	tabMirrors
+	tabWorkspaces
 	tabCount // sentinel
 )
 
@@ -72,21 +76,36 @@ type dashboardModel struct {
 
 	orphanCount int // number of orphan repos found on last scan
 
+	// Workspaces tab state. `workspaceKeys` is the sorted-by-JSON-order
+	// list for deterministic rendering. `workspaceMsg` surfaces the
+	// result of the last inline action (open / delete / regenerate).
+	// `workspaceDeleteConfirm` holds the key awaiting y/n confirmation.
+	workspaceKeys          []string
+	workspaceMsg           string
+	workspaceErr           string
+	workspaceDeleteConfirm string
+
+	// Multi-select on the accounts-tab repo list for the "build a
+	// workspace from selected" entry point. Keys are "sourceKey/repoKey".
+	selectedClones map[string]bool
+
 	showHelp bool
 	version  string
 }
 
 func newDashboardModel(cfg *config.Config, cfgPath string, credMgr *credential.StatusManager, theme styles.Theme, w, h int) dashboardModel {
 	m := dashboardModel{
-		cfg:     cfg,
-		cfgPath: cfgPath,
-		credMgr: credMgr,
-		theme:   theme,
-		width:   w,
-		height:  h,
-		loading: true,
+		cfg:            cfg,
+		cfgPath:        cfgPath,
+		credMgr:        credMgr,
+		theme:          theme,
+		width:          w,
+		height:         h,
+		loading:        true,
+		selectedClones: make(map[string]bool),
 	}
 	m.refreshAccountKeys()
+	m.refreshWorkspaceKeys()
 	// Invalidate all credential statuses so the first render shows "checking",
 	// not a stale result from a previous dashboard instance.
 	for _, k := range m.accountKeys {
@@ -101,6 +120,10 @@ func (m *dashboardModel) refreshAccountKeys() {
 		m.accountKeys = append(m.accountKeys, k)
 	}
 	sort.Strings(m.accountKeys)
+}
+
+func (m *dashboardModel) refreshWorkspaceKeys() {
+	m.workspaceKeys = m.cfg.OrderedWorkspaceKeys()
 }
 
 func (m dashboardModel) Init() tea.Cmd {
@@ -492,6 +515,74 @@ func (m dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 
 		case msg.String() == "a" && m.activeTab == tabAccounts:
 			return m, func() tea.Msg { return switchScreenMsg{screen: screenAccountAdd} }
+
+		// ─── Workspaces tab actions ──────────────────────────────────
+		case m.activeTab == tabWorkspaces && m.workspaceDeleteConfirm != "":
+			// Confirmation intercept: y/n answer the pending delete.
+			switch strings.ToLower(msg.String()) {
+			case "y":
+				key := m.workspaceDeleteConfirm
+				m.workspaceDeleteConfirm = ""
+				return m, workspaceDeleteCmd(m.cfg, m.cfgPath, key)
+			case "n", "esc":
+				m.workspaceDeleteConfirm = ""
+				return m, nil
+			}
+			// Swallow any other key while the confirm is pending.
+			return m, nil
+		case msg.String() == "n" && m.activeTab == tabWorkspaces:
+			return m, func() tea.Msg { return switchScreenMsg{screen: screenWorkspaceAdd} }
+		case msg.String() == "d" && m.activeTab == tabWorkspaces:
+			if i, ok := m.workspaceAtListCursor(); ok {
+				m.workspaceDeleteConfirm = m.workspaceKeys[i]
+				m.workspaceMsg = ""
+				m.workspaceErr = ""
+			}
+			return m, nil
+		case msg.String() == "g" && m.activeTab == tabWorkspaces:
+			if i, ok := m.workspaceAtListCursor(); ok {
+				m.workspaceMsg = ""
+				m.workspaceErr = ""
+				return m, workspaceRegenerateCmd(m.cfg, m.cfgPath, m.workspaceKeys[i])
+			}
+			return m, nil
+		case msg.String() == "o" && m.activeTab == tabWorkspaces:
+			if i, ok := m.workspaceAtListCursor(); ok {
+				m.workspaceMsg = ""
+				m.workspaceErr = ""
+				return m, workspaceOpenCmd(m.cfg, m.cfgPath, m.workspaceKeys[i])
+			}
+			return m, nil
+		// ─── Accounts-tab multi-select ───────────────────────────────
+		case msg.String() == " " && m.activeTab == tabAccounts && m.focus == focusList:
+			// Space toggles selection of the repo under the list cursor.
+			if rk, ok := m.repoKeyAtListCursor(); ok {
+				if m.selectedClones[rk] {
+					delete(m.selectedClones, rk)
+				} else {
+					m.selectedClones[rk] = true
+				}
+			}
+			return m, nil
+		case msg.String() == "A" && m.activeTab == tabAccounts && m.focus == focusList:
+			for _, st := range m.statuses {
+				m.selectedClones[st.Source+"/"+st.Repo] = true
+			}
+			return m, nil
+		case msg.String() == "w" && m.activeTab == tabAccounts && len(m.selectedClones) > 0:
+			// Jump into the add-workspace flow seeded with the current
+			// clone-list selection. The caller converts the set to the
+			// deterministic [source/repo] list carried on the switch.
+			preselect := make([]string, 0, len(m.selectedClones))
+			for k := range m.selectedClones {
+				preselect = append(preselect, k)
+			}
+			sort.Strings(preselect)
+			m.selectedClones = make(map[string]bool)
+			return m, func() tea.Msg {
+				return switchScreenMsg{screen: screenWorkspaceAdd, workspaceMembers: preselect}
+			}
+
 		case msg.String() == "d" && m.activeTab == tabAccounts:
 			// Discovery shortcut for selected account card.
 			if m.focus == focusCards && len(m.accountKeys) > 0 && m.cardCursor < len(m.accountKeys) {
@@ -515,6 +606,25 @@ func (m dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 	case orphansScanDoneMsg:
 		if msg.err == nil {
 			m.orphanCount = len(msg.orphans)
+		}
+		return m, nil
+
+	case workspaceActionResultMsg:
+		if msg.errMsg != "" {
+			m.workspaceErr = msg.errMsg
+			m.workspaceMsg = ""
+		} else {
+			m.workspaceMsg = msg.okMsg
+			m.workspaceErr = ""
+		}
+		if msg.reloadConfig {
+			if fresh, err := config.Load(m.cfgPath); err == nil {
+				m.cfg = fresh
+				m.refreshWorkspaceKeys()
+				if m.listCursor >= len(m.workspaceKeys) && m.listCursor > 0 {
+					m.listCursor = len(m.workspaceKeys) - 1
+				}
+			}
 		}
 		return m, nil
 
@@ -640,6 +750,9 @@ func (m dashboardModel) maxCardIndex() int {
 		return max(0, len(m.accountKeys)-1)
 	case tabMirrors:
 		return max(0, len(m.mirrorSummaries)-1)
+	case tabWorkspaces:
+		// Workspaces tab has no card row today; cursor lives on the list.
+		return 0
 	}
 	return 0
 }
@@ -655,6 +768,8 @@ func (m dashboardModel) listItemCount() int {
 			count += s.Total
 		}
 		return count
+	case tabWorkspaces:
+		return len(m.cfg.Workspaces)
 	}
 	return 0
 }
@@ -690,7 +805,7 @@ func (m dashboardModel) View() string {
 	b.WriteString(m.theme.TextMuted.Render(strings.Repeat("─", max(m.width, 40))) + "\n")
 
 	// Tabs.
-	tabs := []string{"Accounts", "Mirrors"}
+	tabs := []string{"Accounts", "Mirrors", "Workspaces"}
 	var tabLine []string
 	for i, t := range tabs {
 		if tabID(i) == m.activeTab {
@@ -707,6 +822,8 @@ func (m dashboardModel) View() string {
 		b.WriteString(m.viewAccountsTab())
 	case tabMirrors:
 		b.WriteString(m.viewMirrorsTab())
+	case tabWorkspaces:
+		b.WriteString(m.viewWorkspacesTab())
 	}
 
 	// Status bar.
@@ -894,7 +1011,19 @@ func (m dashboardModel) viewRepoList() string {
 		}
 
 		symStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
-		line := fmt.Sprintf("    %s %-10s  %-25s%s  %s%s",
+
+		// Selection marker — only rendered when at least one clone is
+		// selected anywhere. Keeps normal alignment when nothing is.
+		prefix := "    "
+		if len(m.selectedClones) > 0 {
+			if m.selectedClones[r.Source+"/"+r.Repo] {
+				prefix = "  [x] "
+			} else {
+				prefix = "  [ ] "
+			}
+		}
+		line := fmt.Sprintf("%s%s %-10s  %-25s%s  %s%s",
+			prefix,
 			symStyle.Render(sym),
 			symStyle.Render(stateLabel),
 			r.Repo,
@@ -1287,6 +1416,9 @@ func (m dashboardModel) viewStatusBar() string {
 		if errorMirrors > 0 {
 			summary += fmt.Sprintf(", %d error", errorMirrors)
 		}
+	} else if m.activeTab == tabWorkspaces {
+		// Workspace summary.
+		summary = fmt.Sprintf("%d workspace%s", len(m.workspaceKeys), plural(len(m.workspaceKeys)))
 	} else {
 		// Accounts summary.
 		total := len(m.statuses)
@@ -1309,6 +1441,9 @@ func (m dashboardModel) viewStatusBar() string {
 				parts = append(parts, fmt.Sprintf("%d other", other))
 			}
 			summary += ": " + strings.Join(parts, ", ")
+		}
+		if n := len(m.selectedClones); n > 0 {
+			summary += fmt.Sprintf("  |  %d selected (w → workspace)", n)
 		}
 	}
 
@@ -1407,4 +1542,193 @@ func formatStatusDetail(r status.RepoStatus) string {
 	default:
 		return ""
 	}
+}
+
+// ─── Workspaces tab ────────────────────────────────────────────────────────
+
+// workspaceActionResultMsg carries the outcome of an inline workspace
+// action (open / regenerate / delete) back to the dashboard Update loop.
+type workspaceActionResultMsg struct {
+	kind   string // "open" | "regenerate" | "delete"
+	key    string
+	okMsg  string
+	errMsg string
+	// After a successful delete we need the dashboard to reload the
+	// config (so the workspace list re-renders without it).
+	reloadConfig bool
+}
+
+// workspaceOpenCmd generates the workspace artifact (so it's current)
+// and then kicks off BuildOpenCommand. Applies git.HideWindow on
+// Windows to avoid a console flash when we spawn a subprocess.
+func workspaceOpenCmd(cfg *config.Config, cfgPath, wsKey string) tea.Cmd {
+	return func() tea.Msg {
+		res, err := workspace.Generate(cfg, wsKey)
+		if err != nil {
+			return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+		}
+		if err := os.MkdirAll(filepath.Dir(res.File), 0o755); err != nil {
+			return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+		}
+		if err := os.WriteFile(res.File, res.Content, 0o644); err != nil {
+			return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+		}
+		// Persist the file path so Open can find it on the next cycle.
+		ws := cfg.Workspaces[wsKey]
+		if ws.File != res.File {
+			ws.File = res.File
+			if err := cfg.UpdateWorkspace(wsKey, ws); err != nil {
+				return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+			}
+			if err := config.Save(cfg, cfgPath); err != nil {
+				return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+			}
+		}
+		oc, err := workspace.BuildOpenCommand(cfg, wsKey)
+		if err != nil {
+			return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+		}
+		git.HideWindow(oc.Cmd)
+		if err := oc.Cmd.Start(); err != nil {
+			return workspaceActionResultMsg{kind: "open", key: wsKey, errMsg: err.Error()}
+		}
+		return workspaceActionResultMsg{kind: "open", key: wsKey, okMsg: "Launched: " + oc.Description}
+	}
+}
+
+func workspaceRegenerateCmd(cfg *config.Config, cfgPath, wsKey string) tea.Cmd {
+	return func() tea.Msg {
+		res, err := workspace.Generate(cfg, wsKey)
+		if err != nil {
+			return workspaceActionResultMsg{kind: "regenerate", key: wsKey, errMsg: err.Error()}
+		}
+		if err := os.MkdirAll(filepath.Dir(res.File), 0o755); err != nil {
+			return workspaceActionResultMsg{kind: "regenerate", key: wsKey, errMsg: err.Error()}
+		}
+		if err := os.WriteFile(res.File, res.Content, 0o644); err != nil {
+			return workspaceActionResultMsg{kind: "regenerate", key: wsKey, errMsg: err.Error()}
+		}
+		ws := cfg.Workspaces[wsKey]
+		if ws.File != res.File {
+			ws.File = res.File
+			if err := cfg.UpdateWorkspace(wsKey, ws); err != nil {
+				return workspaceActionResultMsg{kind: "regenerate", key: wsKey, errMsg: err.Error()}
+			}
+			if err := config.Save(cfg, cfgPath); err != nil {
+				return workspaceActionResultMsg{kind: "regenerate", key: wsKey, errMsg: err.Error()}
+			}
+		}
+		return workspaceActionResultMsg{kind: "regenerate", key: wsKey, okMsg: fmt.Sprintf("Wrote %s (%d bytes)", res.File, len(res.Content)), reloadConfig: true}
+	}
+}
+
+func workspaceDeleteCmd(cfg *config.Config, cfgPath, wsKey string) tea.Cmd {
+	return func() tea.Msg {
+		if err := cfg.DeleteWorkspace(wsKey); err != nil {
+			return workspaceActionResultMsg{kind: "delete", key: wsKey, errMsg: err.Error()}
+		}
+		if err := config.Save(cfg, cfgPath); err != nil {
+			return workspaceActionResultMsg{kind: "delete", key: wsKey, errMsg: err.Error()}
+		}
+		return workspaceActionResultMsg{kind: "delete", key: wsKey, okMsg: fmt.Sprintf("Deleted workspace %q", wsKey), reloadConfig: true}
+	}
+}
+
+// viewWorkspacesTab renders the inline workspaces list. No card row —
+// workspaces are simple enough that a detail-style list gives us all
+// the information without visual noise.
+func (m dashboardModel) viewWorkspacesTab() string {
+	var b strings.Builder
+
+	if len(m.workspaceKeys) == 0 {
+		b.WriteString("  " + m.theme.TextMuted.Render("No workspaces configured.") + "\n\n")
+		b.WriteString("  " + m.theme.TextMuted.Render("Press n to create one. Select clones on the Accounts tab (space / A) and press w to create a workspace from them.") + "\n")
+	} else {
+		for i, key := range m.workspaceKeys {
+			ws := m.cfg.Workspaces[key]
+			cursor := "  "
+			if m.focus == focusList && i == m.listCursor {
+				cursor = "> "
+			}
+			name := ws.EffectiveName(key)
+			typeTag := ws.Type
+			if typeTag == config.WorkspaceTypeCode {
+				typeTag = "code"
+			} else if typeTag == config.WorkspaceTypeTmuxinator {
+				typeTag = "tmux"
+			}
+			memberCount := len(ws.Members)
+			line := fmt.Sprintf("%s%s  %s  %d member%s",
+				cursor,
+				m.theme.TextBold.Render(fmt.Sprintf("%-20s", name)),
+				m.theme.TextMuted.Render(fmt.Sprintf("[%s]", typeTag)),
+				memberCount,
+				plural(memberCount),
+			)
+			if m.focus == focusList && i == m.listCursor {
+				line = m.theme.Brand.Render(line)
+			}
+			b.WriteString(line + "\n")
+			if ws.File != "" {
+				b.WriteString("    " + m.theme.TextMuted.Render(ws.File) + "\n")
+			} else {
+				b.WriteString("    " + m.theme.TextMuted.Render("(not generated yet)") + "\n")
+			}
+		}
+	}
+
+	if m.workspaceDeleteConfirm != "" {
+		b.WriteString("\n  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.Syncing)).
+			Render(fmt.Sprintf("Delete %q? (y/n)  Generated file is kept on disk.",
+				m.workspaceDeleteConfirm)) + "\n")
+	}
+	if m.workspaceErr != "" {
+		b.WriteString("\n  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.StatusError)).
+			Render("Error: "+m.workspaceErr) + "\n")
+	} else if m.workspaceMsg != "" {
+		b.WriteString("\n  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.Clean)).
+			Render(m.workspaceMsg) + "\n")
+	}
+
+	return b.String()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// workspaceAtListCursor returns the index into m.workspaceKeys of the
+// workspace under the current list cursor, or false when the cursor is
+// outside the workspaces list (wrong tab, empty list, or out of range).
+func (m dashboardModel) workspaceAtListCursor() (int, bool) {
+	if m.activeTab != tabWorkspaces {
+		return 0, false
+	}
+	if len(m.workspaceKeys) == 0 {
+		return 0, false
+	}
+	if m.listCursor < 0 || m.listCursor >= len(m.workspaceKeys) {
+		return 0, false
+	}
+	return m.listCursor, true
+}
+
+// repoKeyAtListCursor returns the "sourceKey/repoKey" of the repo at
+// the current accounts-tab list cursor, or false when that's not
+// meaningful (wrong tab, list empty, etc.).
+func (m dashboardModel) repoKeyAtListCursor() (string, bool) {
+	if m.activeTab != tabAccounts {
+		return "", false
+	}
+	if m.listCursor < 0 || m.listCursor >= len(m.statuses) {
+		return "", false
+	}
+	st := m.statuses[m.listCursor]
+	return st.Source + "/" + st.Repo, true
 }

--- a/cmd/cli/tui/model.go
+++ b/cmd/cli/tui/model.go
@@ -28,6 +28,7 @@ const (
 	screenIdentity
 	screenRepoCreate
 	screenOrphans
+	screenWorkspaceAdd
 )
 
 // --- Navigation messages ---
@@ -39,6 +40,9 @@ type switchScreenMsg struct {
 	repoKey         string // context for repos screen
 	mirrorKey       string // context for mirrors screen
 	forceTokenSetup bool   // go straight to PAT input in credential screen
+	// workspaceMembers seeds the workspace add flow with pre-selected
+	// members (each entry is "sourceKey/repoKey"). Empty for a blank form.
+	workspaceMembers []string
 }
 
 // --- Config messages ---
@@ -208,18 +212,19 @@ type model struct {
 	credMgr       *credential.StatusManager
 
 	// Screen sub-models.
-	dashboard  dashboardModel
-	onboarding onboardingModel
-	account    accountModel
-	accountAdd accountAddModel
-	credential credentialModel
-	discovery  discoveryModel
-	repos      reposModel
-	mirrors    mirrorsModel
-	settings   settingsModel
-	identity   identityModel
-	repoCreate repoCreateModel
-	orphans    orphansModel
+	dashboard    dashboardModel
+	onboarding   onboardingModel
+	account      accountModel
+	accountAdd   accountAddModel
+	credential   credentialModel
+	discovery    discoveryModel
+	repos        reposModel
+	mirrors      mirrorsModel
+	settings     settingsModel
+	identity     identityModel
+	repoCreate   repoCreateModel
+	orphans      orphansModel
+	workspaceAdd workspaceAddModel
 }
 
 func newModel(cfgPath string) model {
@@ -260,6 +265,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.dashboard.theme = m.theme
 			return m, nil
 		}
+		// Global 'w' key: jump to the Workspaces tab from any dashboard
+		// screen. Restricted to the dashboard so it doesn't steal 'w'
+		// presses inside sub-screens that might use it for text input.
+		// If the user has an active repo selection on the Accounts tab,
+		// let the dashboard's own handler take over — that flow opens
+		// the add-workspace screen pre-seeded with the selection.
+		if msg.String() == "w" && m.screen == screenDashboard &&
+			!(m.dashboard.activeTab == tabAccounts && len(m.dashboard.selectedClones) > 0) {
+			m.dashboard.activeTab = tabWorkspaces
+			m.dashboard.cardCursor = 0
+			m.dashboard.listCursor = 0
+			m.dashboard.focus = focusList
+			return m, nil
+		}
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -293,6 +312,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screenRepoCreate:
 			m.repoCreate.width = msg.Width
 			m.repoCreate.height = msg.Height
+		case screenWorkspaceAdd:
+			m.workspaceAdd.width = msg.Width
+			m.workspaceAdd.height = msg.Height
 		}
 		return m, nil
 
@@ -350,6 +372,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.identity, cmd = m.identity.Update(msg)
 	case screenRepoCreate:
 		m.repoCreate, cmd = m.repoCreate.Update(msg)
+	case screenWorkspaceAdd:
+		m.workspaceAdd, cmd = m.workspaceAdd.Update(msg)
 	}
 	return m, cmd
 }
@@ -423,6 +447,9 @@ func (m model) switchTo(msg switchScreenMsg) (model, tea.Cmd) {
 	case screenOrphans:
 		m.orphans = newOrphansModel(m.cfg, m.cfgPath, m.theme, m.width, m.height)
 		cmd = m.orphans.Init()
+	case screenWorkspaceAdd:
+		m.workspaceAdd = newWorkspaceAddModel(m.cfg, m.cfgPath, m.theme, m.width, m.height, msg.workspaceMembers)
+		cmd = m.workspaceAdd.Init()
 	}
 	return m, cmd
 }
@@ -457,6 +484,8 @@ func (m model) View() string {
 		return m.repoCreate.View()
 	case screenOrphans:
 		return m.orphans.View()
+	case screenWorkspaceAdd:
+		return m.workspaceAdd.View()
 	default:
 		return "Unknown screen"
 	}

--- a/cmd/cli/tui/screen_dashboard_test.go
+++ b/cmd/cli/tui/screen_dashboard_test.go
@@ -59,10 +59,16 @@ func TestDashboard_TabSwitch(t *testing.T) {
 		t.Errorf("expected Mirrors tab after Tab, got %d", m.dashboard.activeTab)
 	}
 
-	// Press Tab again → back to Accounts.
+	// Press Tab again → Workspaces tab (third tab added in PR #52).
+	m.dashboard, _ = m.dashboard.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.dashboard.activeTab != tabWorkspaces {
+		t.Errorf("expected Workspaces tab after second Tab, got %d", m.dashboard.activeTab)
+	}
+
+	// Press Tab again → rotates back to Accounts.
 	m.dashboard, _ = m.dashboard.Update(tea.KeyMsg{Type: tea.KeyTab})
 	if m.dashboard.activeTab != tabAccounts {
-		t.Errorf("expected Accounts tab after second Tab, got %d", m.dashboard.activeTab)
+		t.Errorf("expected Accounts tab after third Tab, got %d", m.dashboard.activeTab)
 	}
 }
 

--- a/cmd/cli/tui/screen_launcher.go
+++ b/cmd/cli/tui/screen_launcher.go
@@ -22,6 +22,14 @@ type launcherOverlay struct {
 	path   string // working directory to launch in
 	items  []launcherItem
 	cursor int // index into items; always lands on a selectable entry
+
+	// cfg + cfgPath are kept so launchCurrent can resolve workspace
+	// entries without callers having to thread config through every
+	// launch call. They are only needed for launcherRowWorkspace rows;
+	// all other launchers are self-contained via their editor/term/harness
+	// pointers captured at overlay-build time.
+	cfg     *config.Config
+	cfgPath string
 }
 
 // launcherItemKind tags the row in the flat overlay list.
@@ -32,25 +40,27 @@ const (
 	launcherRowEditor
 	launcherRowTerminal
 	launcherRowHarness
+	launcherRowWorkspace
 )
 
 // launcherItem is one row in the overlay list. Headers use kind
 // launcherRowHeader and an empty payload; selectable rows have exactly one
-// of editor/term/harness set.
+// of editor/term/harness/workspaceKey set.
 type launcherItem struct {
 	kind  launcherItemKind
 	label string
 
-	editor  *config.EditorEntry
-	term    *config.TerminalEntry
-	harness *config.AIHarnessEntry
+	editor       *config.EditorEntry
+	term         *config.TerminalEntry
+	harness      *config.AIHarnessEntry
+	workspaceKey string // only set on launcherRowWorkspace
 }
 
 // newLauncherOverlay builds the overlay items from the current config.
 // Groups appear in the fixed order Terminals / Editors / AI Harnesses;
 // empty groups are omitted entirely (no header for zero entries).
 func newLauncherOverlay(cfg *config.Config) launcherOverlay {
-	lo := launcherOverlay{}
+	lo := launcherOverlay{cfg: cfg}
 	if cfg == nil {
 		return lo
 	}
@@ -83,6 +93,15 @@ func newLauncherOverlay(cfg *config.Config) launcherOverlay {
 	return lo
 }
 
+// withCfgPath records the on-disk config path so workspace launches can
+// persist generated file paths. Returns the updated overlay (the struct
+// is passed by value everywhere else, so this keeps the chained-builder
+// style consistent).
+func (lo launcherOverlay) withCfgPath(p string) launcherOverlay {
+	lo.cfgPath = p
+	return lo
+}
+
 // hasAny reports whether the overlay has any selectable rows.
 func (lo launcherOverlay) hasAny() bool {
 	for _, it := range lo.items {
@@ -96,6 +115,38 @@ func (lo launcherOverlay) hasAny() bool {
 // activate turns the overlay on and sets the working directory launches will
 // target. Callers invoke this on the "open launcher" keypress (o / O).
 func (lo launcherOverlay) activate(path string) launcherOverlay {
+	lo.active = true
+	lo.path = path
+	if lo.cursor < 0 || lo.cursor >= len(lo.items) || lo.items[lo.cursor].kind == launcherRowHeader {
+		lo.cursor = lo.firstSelectable()
+	}
+	return lo
+}
+
+// activateWithWorkspaces is like activate but also splices in a
+// "Workspaces" section at the bottom of the overlay for the given list
+// of workspace keys. Pass an empty slice (or call activate) when the
+// clone has no memberships — no section is rendered in that case.
+// A copy of the base items is kept so subsequent activations rebuild
+// cleanly without duplicating workspace rows.
+func (lo launcherOverlay) activateWithWorkspaces(path string, workspaceKeys []string) launcherOverlay {
+	if len(workspaceKeys) == 0 {
+		return lo.activate(path)
+	}
+	// Separate the base (non-workspace) items from any lingering workspace
+	// rows from a previous activation. This keeps the method idempotent.
+	base := lo.items[:0:0]
+	for _, it := range lo.items {
+		if it.kind != launcherRowWorkspace && !(it.kind == launcherRowHeader && it.label == "Workspaces") {
+			base = append(base, it)
+		}
+	}
+	items := append([]launcherItem{}, base...)
+	items = append(items, launcherItem{kind: launcherRowHeader, label: "Workspaces"})
+	for _, k := range workspaceKeys {
+		items = append(items, launcherItem{kind: launcherRowWorkspace, label: k, workspaceKey: k})
+	}
+	lo.items = items
 	lo.active = true
 	lo.path = path
 	if lo.cursor < 0 || lo.cursor >= len(lo.items) || lo.items[lo.cursor].kind == launcherRowHeader {
@@ -202,6 +253,11 @@ func (lo launcherOverlay) launchCurrent(terminals []config.TerminalEntry) tea.Cm
 			return nil
 		}
 		return launchAIHarnessCmd(lo.path, *it.harness, terminals)
+	case launcherRowWorkspace:
+		if it.workspaceKey == "" || lo.cfg == nil || lo.cfgPath == "" {
+			return nil
+		}
+		return workspaceOpenCmd(lo.cfg, lo.cfgPath, it.workspaceKey)
 	}
 	return nil
 }
@@ -265,6 +321,8 @@ func iconFor(k launcherItemKind) string {
 		return ">_"
 	case launcherRowHarness:
 		return "🤖"
+	case launcherRowWorkspace:
+		return "📦"
 	}
 	return " "
 }

--- a/cmd/cli/tui/screen_repos.go
+++ b/cmd/cli/tui/screen_repos.go
@@ -56,8 +56,26 @@ func newReposModel(cfg *config.Config, cfgPath, sourceKey, repoKey string, theme
 		sourceKey:   sourceKey,
 		repoKey:     repoKey,
 		deleteInput: ti,
-		launcher:    newLauncherOverlay(cfg),
+		launcher:    newLauncherOverlay(cfg).withCfgPath(cfgPath),
 	}
+}
+
+// repoWorkspaceKeys returns the ordered list of workspace keys this
+// clone is a member of. Used to splice a "Workspaces" section into the
+// launcher overlay only when meaningful.
+func (m reposModel) repoWorkspaceKeys() []string {
+	target := m.sourceKey + "/" + m.repoKey
+	var keys []string
+	for _, wsKey := range m.cfg.OrderedWorkspaceKeys() {
+		ws := m.cfg.Workspaces[wsKey]
+		for _, mem := range ws.Members {
+			if mem.Source+"/"+mem.Repo == target {
+				keys = append(keys, wsKey)
+				break
+			}
+		}
+	}
+	return keys
 }
 
 func (m reposModel) repoPath() string {
@@ -565,7 +583,9 @@ func (m reposModel) openLauncher() (reposModel, tea.Cmd) {
 		m.resultMsg = ""
 		return m, nil
 	}
-	m.launcher = m.launcher.activate(path)
+	// Thread workspace memberships into the overlay so the Workspaces
+	// section only appears when this clone belongs to one.
+	m.launcher = m.launcher.activateWithWorkspaces(path, m.repoWorkspaceKeys())
 	m.resultMsg = ""
 	m.errMsg = ""
 	return m, nil

--- a/cmd/cli/tui/screen_workspace_add.go
+++ b/cmd/cli/tui/screen_workspace_add.go
@@ -1,0 +1,375 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/LuisPalacios/gitbox/cmd/cli/tui/styles"
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// workspaceAddView selects which sub-view of the add screen is active.
+type workspaceAddView int
+
+const (
+	workspaceAddViewForm workspaceAddView = iota
+	workspaceAddViewMembers
+)
+
+// workspaceAddModel drives the create-workspace flow: fields at top
+// (key / name / type / layout) and a multi-select member picker below.
+// The two are distinct sub-views so we get a clean single input focus
+// at a time, matching the keyboard-only conventions used elsewhere.
+type workspaceAddModel struct {
+	cfg           *config.Config
+	cfgPath       string
+	theme         styles.Theme
+	width, height int
+
+	view workspaceAddView
+	form formModel
+
+	// All "sourceKey/repoKey" entries, ordered by source then repo.
+	members []string
+	// Index in `members` → selected.
+	selected map[int]bool
+	// Cursor into `members` while in the member view.
+	memberCursor int
+
+	busy    bool
+	errMsg  string
+	okMsg   string
+	done    bool // true after successful create; switches screen back
+}
+
+// workspaceAddSubmittedMsg fires when the config.Save after create
+// succeeds; the screen then switches back to the dashboard.
+type workspaceAddSubmittedMsg struct {
+	key string
+	err error
+}
+
+func newWorkspaceAddModel(cfg *config.Config, cfgPath string, theme styles.Theme, w, h int, preselect []string) workspaceAddModel {
+	// Form fields: key (required), name (optional), type, layout.
+	fields := []formField{
+		newTextField("Key", "e.g. feat-x", 40),
+		newTextField("Name", "Display name (defaults to key)", 60),
+		newSelectFormField("Type", []string{"codeWorkspace", "tmuxinator"}),
+		newSelectFormField("Layout", []string{"windowsPerRepo", "splitPanes"}),
+	}
+	// Validate key on submit.
+	fields[0].ValidateFn = func(v string) string {
+		if strings.TrimSpace(v) == "" {
+			return "key is required"
+		}
+		if _, exists := cfg.Workspaces[v]; exists {
+			return fmt.Sprintf("workspace %q already exists", v)
+		}
+		return ""
+	}
+
+	form := newFormModel("Create workspace", fields, theme)
+
+	// Build the member list in a stable order.
+	var members []string
+	sourceKeys := make([]string, 0, len(cfg.Sources))
+	for k := range cfg.Sources {
+		sourceKeys = append(sourceKeys, k)
+	}
+	sort.Strings(sourceKeys)
+	for _, sk := range sourceKeys {
+		src := cfg.Sources[sk]
+		repoKeys := src.OrderedRepoKeys()
+		if len(repoKeys) == 0 {
+			for rk := range src.Repos {
+				repoKeys = append(repoKeys, rk)
+			}
+			sort.Strings(repoKeys)
+		}
+		for _, rk := range repoKeys {
+			members = append(members, sk+"/"+rk)
+		}
+	}
+
+	selected := make(map[int]bool)
+	for _, pre := range preselect {
+		for i, m := range members {
+			if m == pre {
+				selected[i] = true
+				break
+			}
+		}
+	}
+
+	return workspaceAddModel{
+		cfg:       cfg,
+		cfgPath:   cfgPath,
+		theme:     theme,
+		width:     w,
+		height:    h,
+		view:      workspaceAddViewForm,
+		form:      form,
+		members:   members,
+		selected:  selected,
+	}
+}
+
+func (m workspaceAddModel) Init() tea.Cmd {
+	return m.form.Init()
+}
+
+func (m workspaceAddModel) Update(msg tea.Msg) (workspaceAddModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case workspaceAddSubmittedMsg:
+		m.busy = false
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			return m, nil
+		}
+		m.okMsg = fmt.Sprintf("Workspace %q created.", msg.key)
+		m.done = true
+		return m, func() tea.Msg { return switchScreenMsg{screen: screenDashboard} }
+
+	case tea.KeyMsg:
+		if m.busy {
+			return m, nil
+		}
+		// ESC always cancels back to dashboard unless something has focus.
+		if key.Matches(msg, Keys.Back) {
+			return m, func() tea.Msg { return switchScreenMsg{screen: screenDashboard} }
+		}
+
+		switch m.view {
+		case workspaceAddViewForm:
+			// Tab: hand off to member picker (if members exist).
+			if msg.String() == "tab" && len(m.members) > 0 {
+				m.view = workspaceAddViewMembers
+				return m, nil
+			}
+			submitted, cmd := m.form.Update(msg)
+			if submitted {
+				// Enter on the form advances to the member picker rather
+				// than submitting — users need to pick members first.
+				m.form.submitted = false
+				if len(m.members) == 0 {
+					m.errMsg = "No sources configured — can't pick members"
+					return m, nil
+				}
+				m.view = workspaceAddViewMembers
+				m.errMsg = ""
+				return m, nil
+			}
+			return m, cmd
+
+		case workspaceAddViewMembers:
+			switch {
+			case msg.String() == "tab":
+				m.view = workspaceAddViewForm
+				return m, nil
+			case key.Matches(msg, Keys.Up):
+				if m.memberCursor > 0 {
+					m.memberCursor--
+				}
+				return m, nil
+			case key.Matches(msg, Keys.Down):
+				if m.memberCursor < len(m.members)-1 {
+					m.memberCursor++
+				}
+				return m, nil
+			case msg.String() == " ":
+				m.selected[m.memberCursor] = !m.selected[m.memberCursor]
+				return m, nil
+			case msg.String() == "A":
+				for i := range m.members {
+					m.selected[i] = true
+				}
+				return m, nil
+			case msg.String() == "C":
+				m.selected = make(map[int]bool)
+				return m, nil
+			case key.Matches(msg, Keys.Enter):
+				return m.submit()
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m workspaceAddModel) selectedMembers() []config.WorkspaceMember {
+	out := make([]config.WorkspaceMember, 0, len(m.selected))
+	for i, m2 := range m.members {
+		if !m.selected[i] {
+			continue
+		}
+		slash := strings.IndexByte(m2, '/')
+		if slash <= 0 {
+			continue
+		}
+		out = append(out, config.WorkspaceMember{Source: m2[:slash], Repo: m2[slash+1:]})
+	}
+	return out
+}
+
+func (m workspaceAddModel) submit() (workspaceAddModel, tea.Cmd) {
+	key := strings.TrimSpace(m.form.Fields[0].Value())
+	if key == "" {
+		m.view = workspaceAddViewForm
+		m.form.Active = 0
+		m.form.ErrMsg = "key is required"
+		return m, nil
+	}
+	if _, exists := m.cfg.Workspaces[key]; exists {
+		m.view = workspaceAddViewForm
+		m.form.Active = 0
+		m.form.ErrMsg = fmt.Sprintf("workspace %q already exists", key)
+		return m, nil
+	}
+	members := m.selectedMembers()
+	if len(members) == 0 {
+		m.errMsg = "Select at least one member (space / A)"
+		return m, nil
+	}
+
+	name := strings.TrimSpace(m.form.Fields[1].Value())
+	wsType := m.form.Fields[2].Value()
+	layout := ""
+	if wsType == config.WorkspaceTypeTmuxinator {
+		layout = m.form.Fields[3].Value()
+	}
+
+	ws := config.Workspace{
+		Type:    wsType,
+		Name:    name,
+		Layout:  layout,
+		Members: members,
+	}
+
+	m.busy = true
+	m.errMsg = ""
+
+	cfg := m.cfg
+	cfgPath := m.cfgPath
+	return m, func() tea.Msg {
+		if err := cfg.AddWorkspace(key, ws); err != nil {
+			return workspaceAddSubmittedMsg{err: err}
+		}
+		if err := config.Save(cfg, cfgPath); err != nil {
+			return workspaceAddSubmittedMsg{err: err}
+		}
+		return workspaceAddSubmittedMsg{key: key}
+	}
+}
+
+func (m workspaceAddModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(m.theme.Title.Render("Create workspace") + "\n")
+	b.WriteString(m.theme.TextMuted.Render(strings.Repeat("─", 40)) + "\n\n")
+
+	// Form (always rendered so the user sees the context).
+	b.WriteString(m.renderFormCompact())
+	b.WriteString("\n")
+
+	// Member picker.
+	b.WriteString(m.renderMemberPicker())
+
+	if m.errMsg != "" {
+		b.WriteString("\n  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.StatusError)).
+			Render("Error: "+m.errMsg) + "\n")
+	}
+	if m.okMsg != "" {
+		b.WriteString("\n  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.Clean)).
+			Render(m.okMsg) + "\n")
+	}
+
+	b.WriteString("\n")
+	if m.view == workspaceAddViewForm {
+		b.WriteString(renderHints(m.theme,
+			"↑↓ navigate", "←→ select", "tab members", "enter next", "ESC cancel"))
+	} else {
+		b.WriteString(renderHints(m.theme,
+			"↑↓ move", "space toggle", "A all", "C clear", "tab form", "enter create", "ESC cancel"))
+	}
+	return b.String()
+}
+
+func (m workspaceAddModel) renderFormCompact() string {
+	var b strings.Builder
+	for i, f := range m.form.Fields {
+		active := m.view == workspaceAddViewForm && i == m.form.Active
+		switch f.Kind {
+		case fieldSelect:
+			b.WriteString("  " + f.Select.View(active, m.theme) + "\n")
+		default:
+			label := fmt.Sprintf("  %-8s", f.Label)
+			if active {
+				label = m.theme.Brand.Render(label)
+			} else {
+				label = m.theme.Text.Render(label)
+			}
+			b.WriteString(label + " " + f.TextInput.View() + "\n")
+		}
+	}
+	if m.form.ErrMsg != "" {
+		b.WriteString("  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(m.theme.Palette.StatusError)).
+			Render("Form: "+m.form.ErrMsg) + "\n")
+	}
+	return b.String()
+}
+
+func (m workspaceAddModel) renderMemberPicker() string {
+	var b strings.Builder
+	title := "Members"
+	if m.view == workspaceAddViewMembers {
+		title = m.theme.Brand.Render(title)
+	} else {
+		title = m.theme.Text.Render(title)
+	}
+	selCount := 0
+	for _, v := range m.selected {
+		if v {
+			selCount++
+		}
+	}
+	b.WriteString(fmt.Sprintf("  %s  %s\n", title,
+		m.theme.TextMuted.Render(fmt.Sprintf("%d/%d selected", selCount, len(m.members)))))
+	if len(m.members) == 0 {
+		b.WriteString("  " + m.theme.TextMuted.Render("(no sources configured)") + "\n")
+		return b.String()
+	}
+	// Scroll window centered on cursor when the list is taller than available rows.
+	maxRows := 10
+	start := 0
+	if m.memberCursor > maxRows/2 {
+		start = m.memberCursor - maxRows/2
+	}
+	end := start + maxRows
+	if end > len(m.members) {
+		end = len(m.members)
+	}
+	for i := start; i < end; i++ {
+		marker := "[ ]"
+		if m.selected[i] {
+			marker = "[x]"
+		}
+		cursor := "  "
+		if m.view == workspaceAddViewMembers && i == m.memberCursor {
+			cursor = "> "
+		}
+		line := fmt.Sprintf("%s%s %s", cursor, marker, m.members[i])
+		if m.view == workspaceAddViewMembers && i == m.memberCursor {
+			line = m.theme.Brand.Render(line)
+		} else {
+			line = m.theme.Text.Render(line)
+		}
+		b.WriteString("  " + line + "\n")
+	}
+	return b.String()
+}

--- a/cmd/cli/tui/screen_workspaces_test.go
+++ b/cmd/cli/tui/screen_workspaces_test.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	"github.com/LuisPalacios/gitbox/pkg/status"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newWorkspaceConfig extends newDummyConfig with one pre-configured
+// workspace so tests can cover list / delete / regenerate paths without
+// boilerplate.
+func newWorkspaceConfig(t *testing.T, gitFolder string) *config.Config {
+	t.Helper()
+	cfg := newDummyConfig(t, gitFolder)
+	cfg.Workspaces = map[string]config.Workspace{
+		"feat-x": {
+			Type: config.WorkspaceTypeCode,
+			Name: "Feature X",
+			Members: []config.WorkspaceMember{
+				{Source: "alice-repos", Repo: "alice/hello-world"},
+			},
+		},
+	}
+	cfg.WorkspaceOrder = []string{"feat-x"}
+	return cfg
+}
+
+func TestDashboard_ThirdTabIsWorkspaces(t *testing.T) {
+	cfg := newDummyConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	// Rotate: Accounts → Mirrors → Workspaces.
+	m = sendSpecialKey(m, tea.KeyTab)
+	if m.dashboard.activeTab != tabMirrors {
+		t.Fatalf("after 1 Tab, activeTab = %d, want tabMirrors", m.dashboard.activeTab)
+	}
+	m = sendSpecialKey(m, tea.KeyTab)
+	if m.dashboard.activeTab != tabWorkspaces {
+		t.Fatalf("after 2 Tabs, activeTab = %d, want tabWorkspaces", m.dashboard.activeTab)
+	}
+	m = sendSpecialKey(m, tea.KeyTab)
+	if m.dashboard.activeTab != tabAccounts {
+		t.Fatalf("after 3 Tabs, activeTab = %d, want tabAccounts (rotation)", m.dashboard.activeTab)
+	}
+}
+
+func TestDashboard_GlobalWKeyJumpsToWorkspaces(t *testing.T) {
+	cfg := newDummyConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	if m.dashboard.activeTab != tabAccounts {
+		t.Fatalf("pre: expected Accounts tab, got %d", m.dashboard.activeTab)
+	}
+	m = sendKey(m, "w")
+	if m.dashboard.activeTab != tabWorkspaces {
+		t.Errorf("after 'w', activeTab = %d, want tabWorkspaces", m.dashboard.activeTab)
+	}
+}
+
+func TestDashboard_WorkspacesTab_EmptyStateMessage(t *testing.T) {
+	cfg := newDummyConfig(t, "/tmp/test-git") // no workspaces
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m.dashboard.activeTab = tabWorkspaces
+	view := m.View()
+	if !strings.Contains(view, "No workspaces configured.") {
+		t.Errorf("empty Workspaces tab missing empty-state hint:\n%s", view)
+	}
+}
+
+func TestDashboard_WorkspacesTab_RendersList(t *testing.T) {
+	cfg := newWorkspaceConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m.dashboard.activeTab = tabWorkspaces
+	view := m.View()
+	if !strings.Contains(view, "Feature X") {
+		t.Errorf("Workspaces view missing workspace name:\n%s", view)
+	}
+	if !strings.Contains(view, "[code]") {
+		t.Errorf("Workspaces view missing type tag:\n%s", view)
+	}
+	if !strings.Contains(view, "1 member") {
+		t.Errorf("Workspaces view missing member count:\n%s", view)
+	}
+}
+
+func TestDashboard_WorkspaceDeletePromptsAndCancels(t *testing.T) {
+	cfg := newWorkspaceConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	m.dashboard.activeTab = tabWorkspaces
+	m.dashboard.focus = focusList
+	m.dashboard.listCursor = 0
+
+	// 'd' asks to confirm; config must still contain the workspace.
+	m = sendKey(m, "d")
+	if m.dashboard.workspaceDeleteConfirm != "feat-x" {
+		t.Fatalf("expected delete confirm pending on feat-x, got %q", m.dashboard.workspaceDeleteConfirm)
+	}
+	// 'n' cancels.
+	m = sendKey(m, "n")
+	if m.dashboard.workspaceDeleteConfirm != "" {
+		t.Errorf("expected cancelled confirm, still pending on %q", m.dashboard.workspaceDeleteConfirm)
+	}
+	if _, ok := m.dashboard.cfg.Workspaces["feat-x"]; !ok {
+		t.Error("workspace removed by n cancel — should still be present")
+	}
+}
+
+func TestDashboard_MultiSelectAndWorkspaceShortcut(t *testing.T) {
+	cfg := newDummyConfig(t, "/tmp/test-git")
+	env := setupTestEnvWithConfig(t, cfg)
+	m := newTestModel(t, env.CfgPath)
+	m = initModel(t, m)
+
+	// Seed a small status list aligned with the dummy sources so the
+	// list cursor maps deterministically onto a repo key.
+	m.dashboard.statuses = []status.RepoStatus{
+		{Source: "alice-repos", Repo: "alice/hello-world", State: status.Clean},
+		{Source: "bob-repos", Repo: "bob/my-project", State: status.Clean},
+	}
+	m.dashboard.activeTab = tabAccounts
+	m.dashboard.focus = focusList
+	m.dashboard.listCursor = 0
+
+	// Space toggles selection.
+	m = sendKey(m, " ")
+	if len(m.dashboard.selectedClones) != 1 {
+		t.Fatalf("after space, selected = %d, want 1", len(m.dashboard.selectedClones))
+	}
+	m = sendKey(m, " ")
+	if len(m.dashboard.selectedClones) != 0 {
+		t.Errorf("after second space, selected = %d, want 0", len(m.dashboard.selectedClones))
+	}
+
+	// 'A' selects all visible.
+	m = sendKey(m, "A")
+	if len(m.dashboard.selectedClones) != 2 {
+		t.Errorf("after A, selected = %d, want 2", len(m.dashboard.selectedClones))
+	}
+
+	// 'w' with a selection returns a switchScreenMsg command; pump it
+	// through Update by running the returned cmd and dispatching its
+	// message back.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("w")})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("expected command returned by w with selection, got nil")
+	}
+	msg := cmd()
+	m = sendMsg(m, msg)
+	if m.screen != screenWorkspaceAdd {
+		t.Errorf("after w with selection, screen = %d, want screenWorkspaceAdd", m.screen)
+	}
+	if len(m.dashboard.selectedClones) != 0 {
+		t.Errorf("selection should be cleared after w, got %d entries", len(m.dashboard.selectedClones))
+	}
+}


### PR DESCRIPTION
Closes #52

TUI slice of the dynamic-workspaces feature, closing the three-way CLI / GUI / TUI triangle. Terminal-only users now get the same capabilities already available in the Wails app: create, open, regenerate, and delete workspaces, plus a multi-select workflow on the Accounts tab that feeds a create flow pre-seeded with the chosen clones.

## What changed

- **Third dashboard tab** — `tabWorkspaces` joins Accounts and Mirrors. Inline list view shows each workspace's name, type, member count, and generated file path (or "not generated yet"). Status bar summary follows suit.
- **Keybindings on the Workspaces tab** — `n` new, `d` delete (with y/n confirm — the generated file on disk is kept), `g` regenerate, `o` open. Open / regenerate go through `pkg/workspace.Generate` + `BuildOpenCommand` and apply `git.HideWindow` on Windows.
- **Global `w` key** — from anywhere on the dashboard, jump to the Workspaces tab. Yields to the Accounts-tab `w` handler when a multi-select is active so that flow owns the keystroke.
- **Multi-select on the Accounts repo list** — `space` / `A` toggle selection, `[x]` / `[ ]` prefixes appear on every row, status bar shows `N selected (w → workspace)`. `w` opens the add screen with the selection pre-checked in the member picker.
- **New `screenWorkspaceAdd`** — two-phase form: key / name / type / layout fields on top, multi-select member picker below. Tab toggles focus between them; Enter on the picker validates and persists via `pkg/config` + `pkg/workspace`. ESC cancels.
- **Launcher overlay** — `launcherRowWorkspace` kind plus an `activateWithWorkspaces()` entry point that splices a "Workspaces" section into the per-clone overlay only when the clone has ≥1 membership. Hidden otherwise.
- **Tests** — unit tests cover the tab rotation, the global-`w` jump, the Workspaces tab empty and populated renderings, the delete confirm/cancel flow, and the multi-select → `w` → `screenWorkspaceAdd` handoff (including selection clearing). The pre-existing `TestDashboard_TabSwitch` was extended to account for the third tab.

## Test plan

- [ ] `gitbox` launches the TUI and shows three tabs. `Tab` rotates Accounts → Mirrors → Workspaces → Accounts.
- [ ] On any dashboard screen, pressing `w` jumps straight to the Workspaces tab.
- [ ] With no workspaces configured, the Workspaces tab shows the empty-state hint. `n` opens the add screen.
- [ ] Add a workspace from the TUI: fill key + pick ≥1 member + Enter. Lands back on the Workspaces tab with the new entry.
- [ ] On a workspace row, `o` launches via the first configured editor; `g` regenerates; `d` + `y` deletes from the config (file on disk kept).
- [ ] On the Accounts tab, `space` / `A` populate `[x]` / `[ ]` markers on repo rows, status bar updates, `w` opens the add screen with members pre-checked.
- [ ] In the per-clone repos screen, `O` opens the launcher overlay. When the clone belongs to a workspace, a "Workspaces" section appears with 📦 entries; Enter on one launches it via the configured editor. Clones with zero memberships do not show the section.
- [ ] Existing keys (`N`, `a`, `d` on cards, `s`, `i`, `O`, `t`, `?`) are unchanged.
- [ ] No `cmd.exe` flash on Windows during any workspace launch.
- [ ] `gitbox workspace list` from the CLI (PR #48) sees workspaces created through the TUI.
- [ ] GUI launch unaffected (no cross-binary regressions).