### PR TITLE
GUI: tighten chrome — workspace badge as open action, no text selection, PR badges left of sync, icon select toggle

### DIFF
--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1496,6 +1496,23 @@
     openPRPopover = openPRPopover === key ? null : key;
   }
 
+  // Which workspace popover is open: keyed by `${sourceKey}/${repoName}` or null.
+  // Driven by the workspace badge on each clone row; lists every workspace the
+  // clone belongs to, opens one on click and dismisses itself.
+  let openWsPopover: string | null = null;
+  function toggleWsPopover(key: string) {
+    openWsPopover = openWsPopover === key ? null : key;
+  }
+  async function openWorkspaceFromBadge(wsKey: string) {
+    openWsPopover = null;
+    await openWorkspace(wsKey);
+  }
+  function workspaceLabel(wsKey: string): string {
+    const ws = $workspaces[wsKey];
+    if (!ws) return wsKey;
+    return ws.name && ws.name !== wsKey ? `${ws.name} (${wsKey})` : wsKey;
+  }
+
   // Build the provider-native "all PRs" URL for a given repo full name.
   function providerPRsURL(providerName: string, baseURL: string, repoFull: string): string {
     const base = (baseURL || '').replace(/\/+$/, '') || defaultProviderBase(providerName);
@@ -1802,8 +1819,12 @@
 
 <svelte:window on:click={(e) => {
   const inMenu = e.target instanceof Element && e.target.closest('.action-menu-container');
+  const inWsPopover = e.target instanceof Element && e.target.closest('.ws-popover, .ws-badge');
   if (actionMenuRepo && !inMenu) closeActionMenu();
   if (actionMenuAccount && !inMenu) closeAccountMenu();
+  if (openWsPopover && !inWsPopover) openWsPopover = null;
+}} on:keydown={(e) => {
+  if (e.key === 'Escape' && openWsPopover) openWsPopover = null;
 }} />
 
 <!-- ════════════════════════════════════════════════════════════ -->
@@ -1991,7 +2012,6 @@
         </g>
       </svg>
       <span class="title">gitbox</span>
-      <span class="tagline">accounts & clones</span>
     </div>
     <div class="health">
       <span class="health-ring" style="--pct: {$summary.total ? ($summary.clean / $summary.total) * 100 : 0}">
@@ -2020,6 +2040,7 @@
         <span class="sync-icon" class:spinning={fetchingAll}>&#8635;</span>
       </button>
       <button class="btn-gear btn-trash" class:delete-active={deleteMode} on:click={() => deleteMode = !deleteMode} disabled={Object.keys($accounts).length === 0} title="{deleteMode ? 'Exit delete mode' : 'Delete mode'}">&#128465;</button>
+      <button class="btn-gear btn-select" class:select-active={selectionMode} on:click={toggleSelectionMode} disabled={cardsTab !== 'accounts' || Object.keys($accounts).length === 0} title="{selectionMode ? 'Exit selection mode' : 'Toggle clone selection mode'}">{selectionMode ? '☑' : '☐'}</button>
       <button class="btn-gear" on:click={toggleViewMode} title="Compact view">◧</button>
       <button class="btn-gear" on:click={cycleTheme} title="Theme: {themeChoice}">{themeIcon(themeChoice)}</button>
       <button class="btn-gear" on:click={() => showSettings = !showSettings} title="Settings" class:active-gear={showSettings}>&#9881;</button>
@@ -2085,21 +2106,19 @@
         </div>
       {/if}
       <div class="settings-row">
-        <span class="settings-label">PR / review badges</span>
+        <span class="settings-label">PR / reviews</span>
         <div class="theme-toggle">
           <button class="theme-btn" class:theme-active={!$prSettings.enabled} on:click={() => { if ($prSettings.enabled) setPRBadgesEnabled(false); }}>Off</button>
           <button class="theme-btn" class:theme-active={$prSettings.enabled} on:click={() => { if (!$prSettings.enabled) setPRBadgesEnabled(true); }}>On</button>
         </div>
-      </div>
-      {#if $prSettings.enabled}
-        <div class="settings-row">
-          <span class="settings-label">Include drafts in &#128221;</span>
+        {#if $prSettings.enabled}
+          <span class="settings-sublabel">Include drafts</span>
           <div class="theme-toggle">
             <button class="theme-btn" class:theme-active={!$prSettings.includeDrafts} on:click={() => { if ($prSettings.includeDrafts) setPRIncludeDrafts(false); }}>Off</button>
             <button class="theme-btn" class:theme-active={$prSettings.includeDrafts} on:click={() => { if (!$prSettings.includeDrafts) setPRIncludeDrafts(true); }}>On</button>
           </div>
-        </div>
-      {/if}
+        {/if}
+      </div>
       <div class="settings-row">
         <span class="settings-label">Version</span>
         <span class="settings-value">{appVersion}</span>
@@ -2116,9 +2135,9 @@
     <button class="cards-tab" class:cards-tab-active={cardsTab === 'accounts'}
       on:click={() => cardsTab = 'accounts'}>Accounts</button>
     <button class="cards-tab" class:cards-tab-active={cardsTab === 'mirrors'}
-      on:click={() => cardsTab = 'mirrors'}>Mirrors</button>
+      on:click={() => { cardsTab = 'mirrors'; if (selectionMode) toggleSelectionMode(); }}>Mirrors</button>
     <button class="cards-tab" class:cards-tab-active={cardsTab === 'workspaces'}
-      on:click={() => cardsTab = 'workspaces'}>Workspaces</button>
+      on:click={() => { cardsTab = 'workspaces'; if (selectionMode) toggleSelectionMode(); }}>Workspaces</button>
     {#if orphanCount > 0}
       <button class="orphan-pill" on:click={showOrphanModal}>{orphanCount} orphan{orphanCount > 1 ? 's' : ''}</button>
     {/if}
@@ -2126,14 +2145,6 @@
       <div class="tab-bar-actions">
         <button class="btn-tab-action" on:click={runMirrorDiscover} disabled={mirrorDiscoverLoading}>{mirrorDiscoverLoading ? 'Scanning...' : 'Discover'}</button>
         <button class="btn-tab-action" on:click={checkAllMirrorStatus}>Check all</button>
-      </div>
-    {/if}
-    {#if cardsTab === 'accounts'}
-      <div class="tab-bar-actions">
-        <button class="btn-tab-action" class:tab-action-active={selectionMode} on:click={toggleSelectionMode}
-          title={selectionMode ? 'Exit selection mode' : 'Select clones to build a workspace'}>
-          {selectionMode ? 'Exit select' : 'Select clones'}
-        </button>
       </div>
     {/if}
     {#if cardsTab === 'workspaces'}
@@ -2241,14 +2252,32 @@
               <button class="btn-delete-x" on:click|stopPropagation={() => askDelete(sourceKey, repoName, state.status)} title="Delete {repoName}">&#10005;</button>
             {/if}
             <span class="dot" style="color: {sc(state.status)}">{statusSymbol(state.status)}</span>
+            {#if membershipsFor(repoKey).length > 0}
+              <div class="ws-badge-wrap">
+                <button class="ws-badge"
+                        title="Member of: {membershipsFor(repoKey).map(workspaceLabel).join(', ')}"
+                        on:click|stopPropagation={() => toggleWsPopover(repoKey)}>
+                  📦
+                </button>
+                {#if openWsPopover === repoKey}
+                  <div class="ws-popover" transition:fade={{ duration: 80 }} on:click|stopPropagation>
+                    <div class="ws-popover-title">Open workspace</div>
+                    {#each membershipsFor(repoKey) as wsKey}
+                      <button class="ws-popover-item"
+                              on:click={() => openWorkspaceFromBadge(wsKey)}
+                              disabled={workspaceBusy}>
+                        📦 {workspaceLabel(wsKey)}
+                      </button>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
+            {/if}
             <span class="repo-name">{repoName}</span>
             {#if state.branch === '(detached)'}
               <span class="branch-badge detached">detached</span>
             {:else if state.branch && !state.isDefault}
               <span class="branch-badge">{state.branch}</span>
-            {/if}
-            {#if membershipsFor(repoKey).length > 0}
-              <span class="ws-badge" title="Member of: {membershipsFor(repoKey).join(', ')}">📦 {membershipsFor(repoKey).length}</span>
             {/if}
 
             {#if state.status === 'syncing' || state.status === 'cloning'}
@@ -2257,32 +2286,6 @@
               </div>
               <span class="progress-pct" style="color:{sc(state.status)}">{state.progress}%</span>
             {:else}
-              <span class="status-badges">
-                {#if state.status === 'clean'}
-                  <span class="status-text" style="color:{sc('clean')}">Synced</span>
-                {:else if state.status === 'not cloned'}
-                  <span class="status-text" style="color:{sc('not cloned')}">Not local</span>
-                {:else if state.status === 'no upstream'}
-                  {#if state.isDefault}
-                    <span class="status-text" style="color:{sc('no upstream')}">No upstream</span>
-                  {:else}
-                    <span class="status-text" style="color:{sc('clean')}">Local branch</span>
-                  {/if}
-                {:else if state.status === 'error'}
-                  <span class="status-text" style="color:{sc('error')}">Error</span>
-                {:else}
-                  <span class="status-pending">Pending</span>
-                  {#if state.behind > 0}<span class="sbadge" style="color:{sc('behind')}" title="{state.behind} behind">↓{state.behind}</span>{/if}
-                  {#if state.ahead > 0}<span class="sbadge" style="color:{sc('ahead')}" title="{state.ahead} ahead">↑{state.ahead}</span>{/if}
-                  {#if state.modified > 0}<span class="sbadge" style="color:{sc('dirty')}" title="{state.modified} changed">✎{state.modified}</span>{/if}
-                  {#if state.untracked > 0}<span class="sbadge" style="color:{sc('not cloned')}" title="{state.untracked} untracked">?{state.untracked}</span>{/if}
-                {/if}
-              </span>
-              {#if state.status === 'behind'}
-                <button class="btn-action" on:click|stopPropagation={() => syncRepo(sourceKey, repoName)}>Pull</button>
-              {:else if state.status === 'not cloned'}
-                <button class="btn-action" on:click|stopPropagation={() => cloneRepo(sourceKey, repoName)}>Bring Local</button>
-              {/if}
               {#if !deleteMode && $prSettings.enabled}
                 {@const prSummary = lookupPRSummary($prsByAccount, accountKey, repoName)}
                 {@const acctForPRs = $accounts[accountKey]}
@@ -2325,6 +2328,32 @@
                   </div>
                 {/if}
               {/if}
+              <span class="status-badges">
+                {#if state.status === 'clean'}
+                  <span class="status-text" style="color:{sc('clean')}">Synced</span>
+                {:else if state.status === 'not cloned'}
+                  <span class="status-text" style="color:{sc('not cloned')}">Not local</span>
+                {:else if state.status === 'no upstream'}
+                  {#if state.isDefault}
+                    <span class="status-text" style="color:{sc('no upstream')}">No upstream</span>
+                  {:else}
+                    <span class="status-text" style="color:{sc('clean')}">Local branch</span>
+                  {/if}
+                {:else if state.status === 'error'}
+                  <span class="status-text" style="color:{sc('error')}">Error</span>
+                {:else}
+                  <span class="status-pending">Pending</span>
+                  {#if state.behind > 0}<span class="sbadge" style="color:{sc('behind')}" title="{state.behind} behind">↓{state.behind}</span>{/if}
+                  {#if state.ahead > 0}<span class="sbadge" style="color:{sc('ahead')}" title="{state.ahead} ahead">↑{state.ahead}</span>{/if}
+                  {#if state.modified > 0}<span class="sbadge" style="color:{sc('dirty')}" title="{state.modified} changed">✎{state.modified}</span>{/if}
+                  {#if state.untracked > 0}<span class="sbadge" style="color:{sc('not cloned')}" title="{state.untracked} untracked">?{state.untracked}</span>{/if}
+                {/if}
+              </span>
+              {#if state.status === 'behind'}
+                <button class="btn-action" on:click|stopPropagation={() => syncRepo(sourceKey, repoName)}>Pull</button>
+              {:else if state.status === 'not cloned'}
+                <button class="btn-action" on:click|stopPropagation={() => cloneRepo(sourceKey, repoName)}>Bring Local</button>
+              {/if}
               {#if !deleteMode && state.status !== 'not cloned'}
                 <button class="btn-fetch" class:spinning={fetchingRepos[repoKey]} on:click|stopPropagation={() => fetchRepo(sourceKey, repoName)} title="Fetch origin" disabled={!!fetchingRepos[repoKey]}>&#8635;</button>
                 <div class="action-menu-container">
@@ -2336,13 +2365,11 @@
                         editors={configEditors}
                         terminals={configTerminals}
                         aiHarnesses={configAIHarnesses}
-                        workspaceKeys={membershipsFor(repoKey)}
                         onOpenBrowser={() => openRepoInBrowser(sourceKey, repoName)}
                         onOpenFolder={() => openRepoInExplorer(repoKey)}
                         onOpenApp={(cmd) => openRepoInApp(repoKey, cmd)}
                         onOpenTerminal={(t) => openRepoInTerminal(repoKey, t)}
                         onOpenAIHarness={(h) => openRepoInAIHarness(repoKey, h)}
-                        onOpenWorkspace={(k) => openWorkspace(k)}
                         onSweep={() => sweepBranches(sourceKey, repoName)}
                       />
                     </div>
@@ -3655,6 +3682,23 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', system-ui, sans-serif;
     color: var(--text-primary); -webkit-font-smoothing: antialiased;
     transition: background 0.2s, color 0.2s;
+    /* GUI chrome is not for copy-paste — drag-select on cards / labels /
+       repo rows is noise, and Ctrl-A nukes the whole window. Inputs and
+       editable surfaces opt back in below. Add `.selectable` on any
+       element that genuinely needs copyable text. */
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+  }
+  :global(input),
+  :global(textarea),
+  :global([contenteditable="true"]),
+  :global(pre),
+  :global(code),
+  :global(.selectable) {
+    user-select: text;
+    -webkit-user-select: text;
+    -ms-user-select: text;
   }
 
   .app { max-width: 860px; margin: 0 auto; height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
@@ -3682,7 +3726,6 @@
   .brand { display: flex; align-items: center; gap: 8px; }
   .logo-svg { width: 26px; height: 26px; }
   .title { font-size: 17px; font-weight: 700; letter-spacing: -0.3px; }
-  .tagline { font-size: 11px; font-weight: 400; color: var(--text-muted); letter-spacing: 0.3px; margin-left: 6px; white-space: nowrap; }
 
   .health { display: flex; align-items: center; gap: 8px; margin-left: auto; }
   .health-ring {
@@ -3708,6 +3751,8 @@
   .btn-gear:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-hover); }
   .btn-gear:disabled { opacity: 0.3; cursor: default; }
   .btn-trash { font-size: 15px; }
+  .btn-select { font-size: 15px; }
+  .select-active { color: var(--text-primary) !important; background: var(--bg-hover) !important; }
 
   .cards-tab-bar { display: flex; gap: 4px; padding: 12px 24px 0; align-items: center; }
   .tab-bar-actions { margin-left: auto; display: flex; gap: 6px; }
@@ -3940,6 +3985,7 @@
   }
   .settings-row { display: flex; align-items: center; gap: 12px; }
   .settings-label { font-size: 11px; font-weight: 600; color: var(--text-muted); width: 80px; flex-shrink: 0; }
+  .settings-sublabel { font-size: 11px; font-weight: 500; color: var(--text-muted); margin-left: 12px; flex-shrink: 0; }
   .settings-value { font-size: 12px; color: var(--text-secondary); font-family: monospace; flex: 1; }
   .settings-btn {
     padding: 2px 8px; font-size: 10px; font-weight: 500;
@@ -4442,16 +4488,68 @@
   /* Small membership count chip on clone rows. Sits beside the branch
      badge and stays subtle — presence of the chip at all is already the
      signal the clone is in a workspace. */
-  .ws-badge {
-    font-size: 10px;
-    padding: 1px 6px;
-    margin-left: 4px;
-    border-radius: 10px;
-    background: var(--bg-raised);
-    color: var(--text-muted);
-    white-space: nowrap;
+  .ws-badge-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
     flex: 0 0 auto;
   }
+  /* Now an action button: clicking it opens the workspace popover. The icon
+     alone signals membership; the count is gone (the popover lists the
+     workspaces by name). */
+  .ws-badge {
+    font-size: 13px;
+    line-height: 1;
+    padding: 2px 4px;
+    margin-right: 4px;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background 0.12s;
+  }
+  .ws-badge:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .ws-badge:focus-visible { outline: 1px solid var(--border-hover); outline-offset: 1px; }
+  .ws-popover {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 30;
+    min-width: 200px;
+    max-width: 320px;
+    padding: 6px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ws-popover-title {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--text-muted);
+    padding: 4px 8px 2px;
+  }
+  .ws-popover-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 12px;
+    text-align: left;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .ws-popover-item:hover:not(:disabled) { background: var(--bg-hover); }
+  .ws-popover-item:disabled { opacity: 0.5; cursor: not-allowed; }
 
   /* Workspace card styling: reuse the mirror card structure but with its
      own dot colour derived inline. */

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1938,7 +1938,7 @@
         <div class="compact-repo-list" transition:slide={{ duration: 120 }}>
           {#each ($sources[key].repoOrder || Object.keys($sources[key].repos)) as repoName}
             {@const repoKey = `${key}/${repoName}`}
-            {@const state = $repoStates[repoKey] || { status: 'error', behind: 0, modified: 0, ahead: 0 }}
+            {@const state = $repoStates[repoKey] || { status: 'unknown', behind: 0, modified: 0, ahead: 0 }}
             <div class="compact-row" class:compact-row-ok={state.status === 'clean'}>
               <span class="compact-dot" style="color: {sc(state.status)}">{statusSymbol(state.status)}</span>
               <span class="compact-repo-name">{repoName.includes('/') ? repoName.split('/').pop() : repoName}</span>
@@ -2237,9 +2237,9 @@
         </div>
         {#each (source.repoOrder && source.repoOrder.length > 0 ? source.repoOrder : Object.keys(source.repos)) as repoName (repoName)}
           {@const repoKey = `${sourceKey}/${repoName}`}
-          {@const state = $repoStates[repoKey] || { status: 'error', progress: 0, behind: 0, modified: 0, untracked: 0, ahead: 0 }}
-          <div class="repo-row" class:repo-row-clickable={state.status !== 'clean' && state.status !== 'behind' && state.status !== 'not cloned' && state.status !== 'cloning' && state.status !== 'syncing'}
-            on:click={() => { if (selectionMode) { toggleCloneSelection(repoKey); } else { toggleRepoDetail(sourceKey, repoName, state.status); } }}>
+          {@const state = $repoStates[repoKey] || { status: 'unknown', progress: 0, behind: 0, modified: 0, untracked: 0, ahead: 0 }}
+          <div class="repo-row" class:repo-row-clickable={state.status !== 'unknown' && state.status !== 'clean' && state.status !== 'behind' && state.status !== 'not cloned' && state.status !== 'cloning' && state.status !== 'syncing'}
+            on:click={() => { if (selectionMode) { toggleCloneSelection(repoKey); } else if (state.status !== 'unknown') { toggleRepoDetail(sourceKey, repoName, state.status); } }}>
             {#if selectionMode}
               <input type="checkbox" class="clone-select-box" checked={$selectedClones.has(repoKey)}
                 on:click|stopPropagation
@@ -2281,6 +2281,11 @@
                 <div class="progress-fill" style="width:{state.progress}%; background:{sc(state.status)}"></div>
               </div>
               <span class="progress-pct" style="color:{sc(state.status)}">{state.progress}%</span>
+            {:else if state.status === 'unknown'}
+              <!-- First scan hasn't completed yet — render no status text,
+                   no pull/PR badges, no sync icon, no kebab. The row stays
+                   visually empty on the right rather than lying with an
+                   "Error" / red ✕ until the scan resolves. -->
             {:else}
               {#if !deleteMode && $prSettings.enabled}
                 {@const prSummary = lookupPRSummary($prsByAccount, accountKey, repoName)}

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2281,12 +2281,8 @@
                 <div class="progress-fill" style="width:{state.progress}%; background:{sc(state.status)}"></div>
               </div>
               <span class="progress-pct" style="color:{sc(state.status)}">{state.progress}%</span>
-            {:else if state.status === 'unknown'}
-              <!-- First scan hasn't completed yet — render no status text,
-                   no pull/PR badges, no sync icon, no kebab. The row stays
-                   visually empty on the right rather than lying with an
-                   "Error" / red ✕ until the scan resolves. -->
             {:else}
+              {#if state.status !== 'unknown'}
               {#if !deleteMode && $prSettings.enabled}
                 {@const prSummary = lookupPRSummary($prsByAccount, accountKey, repoName)}
                 {@const acctForPRs = $accounts[accountKey]}
@@ -2355,8 +2351,9 @@
               {:else if state.status === 'not cloned'}
                 <button class="btn-action" on:click|stopPropagation={() => cloneRepo(sourceKey, repoName)}>Bring Local</button>
               {/if}
+              {/if}
               {#if !deleteMode && state.status !== 'not cloned'}
-                <button class="btn-fetch" class:spinning={fetchingRepos[repoKey]} on:click|stopPropagation={() => fetchRepo(sourceKey, repoName)} title="Fetch origin" disabled={!!fetchingRepos[repoKey]}>&#8635;</button>
+                <button class="btn-fetch" class:spinning={fetchingRepos[repoKey] || state.status === 'unknown'} on:click|stopPropagation={() => fetchRepo(sourceKey, repoName)} title="Fetch origin" disabled={!!fetchingRepos[repoKey]}>&#8635;</button>
                 <div class="action-menu-container">
                   <button class="btn-kebab" on:click|stopPropagation={() => toggleActionMenu(repoKey)} title="Actions">&#8942;</button>
                   {#if actionMenuRepo === repoKey}

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1539,7 +1539,12 @@
 
   async function runFetchAll() {
     fetchingAll = true;
-    bridge.fetchAllRepos();
+    try {
+      await bridge.fetchAllRepos();
+    } catch (e) {
+      fetchingAll = false;
+      lastFetchTime = 'fetch-all error: ' + (e instanceof Error ? e.message : String(e));
+    }
   }
 
   // ── Credential status cache ──
@@ -1693,7 +1698,7 @@
       fetchingAll = false;
       fetchingRepos = {};
       const now = new Date();
-      lastFetchTime = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      lastFetchTime = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
       verifyAllCredentials();
     });
 

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -2153,17 +2153,13 @@
         <button class="btn-tab-action" title="Scan disk for new workspace files" on:click={async () => { await bridge.discoverWorkspaces(); }}>Discover</button>
       </div>
     {/if}
-  </div>
-
-  {#if cardsTab === 'accounts' && selectionMode && $selectedClones.size > 0}
-    <div class="selection-bar">
-      <span class="selection-count">{$selectedClones.size} clone{$selectedClones.size === 1 ? '' : 's'} selected</span>
-      <div class="selection-actions">
-        <button class="btn-tab-action" on:click={openWorkspaceModalFromSelection}>Create workspace from selected</button>
-        <button class="btn-tab-action" on:click={() => clearCloneSelection()}>Clear</button>
+    {#if cardsTab === 'accounts' && selectionMode && $selectedClones.size > 0}
+      <div class="tab-bar-actions">
+        <button class="btn-tab-action" on:click={openWorkspaceModalFromSelection} title="Create a workspace from the selected clones">+ Workspace</button>
+        <button class="btn-tab-action" on:click={() => clearCloneSelection()} title="Clear selection">Clear</button>
       </div>
-    </div>
-  {/if}
+    {/if}
+  </div>
 
   {#if cardsTab === 'accounts'}
   <!-- ── ACCOUNT CARDS ── -->
@@ -4458,22 +4454,6 @@
     color: var(--text-primary) !important;
     border-color: var(--border-hover) !important;
   }
-
-  /* Floating bar at the top of the accounts tab when clones are selected. */
-  .selection-bar {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 12px;
-    margin: 0 24px 8px;
-    padding: 10px 14px;
-    background: var(--bg-card);
-    border: 1px solid var(--border-hover);
-    border-radius: 8px;
-    position: sticky;
-    top: 0;
-    z-index: 40;
-  }
-  .selection-count { font-size: 12px; color: var(--text-primary); font-weight: 600; }
-  .selection-actions { display: flex; gap: 6px; }
 
   /* Per-row checkbox shown in selection mode. Sized to match the delete-X
      button it visually replaces so the row layout stays stable. */

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -4488,32 +4488,41 @@
   /* Small membership count chip on clone rows. Sits beside the branch
      badge and stays subtle — presence of the chip at all is already the
      signal the clone is in a workspace. */
+  /* Negative margins claw back the .repo-row `gap: 10px` on each side so
+     the badge sits visually flush against the status dot and the repo
+     name, instead of looking like a 50px-wide gutter. */
   .ws-badge-wrap {
     position: relative;
     display: inline-flex;
     align-items: center;
     flex: 0 0 auto;
+    margin-left: -6px;
+    margin-right: -4px;
   }
   /* Now an action button: clicking it opens the workspace popover. The icon
      alone signals membership; the count is gone (the popover lists the
-     workspaces by name). */
+     workspaces by name). Compact footprint — one emoji glyph, tight padding,
+     no border. */
   .ws-badge {
     font-size: 13px;
     line-height: 1;
-    padding: 2px 4px;
-    margin-right: 4px;
+    padding: 2px 3px;
     border: none;
     background: transparent;
     color: var(--text-muted);
     cursor: pointer;
-    border-radius: 6px;
+    border-radius: 4px;
     transition: background 0.12s;
   }
   .ws-badge:hover { background: var(--bg-hover); color: var(--text-primary); }
   .ws-badge:focus-visible { outline: 1px solid var(--border-hover); outline-offset: 1px; }
+  /* Anchor ABOVE the badge — bottom rows would otherwise spawn the popover
+     beneath the visible viewport and need scrolling to reveal it. The
+     popover is at most 3-5 entries tall so opening upward fits comfortably
+     even for rows near the very top of the cards area. */
   .ws-popover {
     position: absolute;
-    top: calc(100% + 4px);
+    bottom: calc(100% + 4px);
     left: 0;
     z-index: 30;
     min-width: 200px;

--- a/cmd/gui/frontend/src/lib/LauncherMenu.svelte
+++ b/cmd/gui/frontend/src/lib/LauncherMenu.svelte
@@ -26,17 +26,12 @@
   export let editors: EditorInfo[] = [];
   export let terminals: TerminalInfo[] = [];
   export let aiHarnesses: AIHarnessInfo[] = [];
-  // Ordered list of workspace keys this clone belongs to. Empty (default)
-  // hides the "Open workspace" section entirely. Only meaningful for the
-  // repo-row kebab.
-  export let workspaceKeys: string[] = [];
 
   export let onOpenBrowser: () => void;
   export let onOpenFolder: () => void;
   export let onOpenApp: (command: string) => void;
   export let onOpenTerminal: (terminal: TerminalInfo) => void;
   export let onOpenAIHarness: (harness: AIHarnessInfo) => void;
-  export let onOpenWorkspace: ((workspaceKey: string) => void) | null = null;
   export let onSweep: (() => void) | null = null;
 
   type Sub = 'terminals' | 'editors' | 'ai' | 'workspaces' | null;
@@ -186,7 +181,6 @@
   $: hasDefaultsSection = showTerminalDefault || showEditorDefault || showHarnessDefault;
   $: hasSubsSection = showTerminalsSub || showEditorsSub || showHarnessSub;
   $: hasSweepSection = kind === 'repo' && !!onSweep;
-  $: hasWorkspacesSection = kind === 'repo' && !!onOpenWorkspace && workspaceKeys.length > 0;
 </script>
 
 <div class="action-dropdown launcher-menu" bind:this={rootEl}>
@@ -269,25 +263,6 @@
         {/if}
       </div>
     {/if}
-  {/if}
-
-  {#if hasWorkspacesSection}
-    <hr class="lm-sep" />
-    <div class="lm-sub-container">
-      <button class="action-item lm-submenu-trigger" class:lm-active={openSubmenu === 'workspaces'} on:click|stopPropagation={() => toggleSub('workspaces')}>
-        <span class="lm-icon">&#128230;</span> Open workspace
-        <span class="lm-arrow">&#9654;</span>
-      </button>
-      {#if openSubmenu === 'workspaces'}
-        <div class="action-dropdown launcher-submenu" bind:this={subEl}>
-          {#each workspaceKeys as wsKey}
-            <button class="action-item" on:click|stopPropagation={() => onOpenWorkspace && onOpenWorkspace(wsKey)}>
-              <span class="lm-icon">&#128230;</span> {wsKey}
-            </button>
-          {/each}
-        </div>
-      {/if}
-    </div>
   {/if}
 
   {#if hasSweepSection}

--- a/cmd/gui/frontend/src/lib/theme.ts
+++ b/cmd/gui/frontend/src/lib/theme.ts
@@ -60,6 +60,9 @@ export function statusSymbol(status: string): string {
     clean: '●', behind: '◗', dirty: '◆', ahead: '▲',
     syncing: '◔', cloning: '◔', fetching: '◔', 'not cloned': '○',
     'no upstream': '~', diverged: '⚠', conflict: '⚡', error: '✕',
+    // 'unknown' = first scan hasn't completed yet. Render no glyph so the
+    // row doesn't lie about state during the startup window.
+    unknown: '',
   };
   return map[status] || '?';
 }

--- a/cmd/gui/frontend/src/lib/theme.ts
+++ b/cmd/gui/frontend/src/lib/theme.ts
@@ -60,9 +60,12 @@ export function statusSymbol(status: string): string {
     clean: '●', behind: '◗', dirty: '◆', ahead: '▲',
     syncing: '◔', cloning: '◔', fetching: '◔', 'not cloned': '○',
     'no upstream': '~', diverged: '⚠', conflict: '⚡', error: '✕',
-    // 'unknown' = first scan hasn't completed yet. Render no glyph so the
-    // row doesn't lie about state during the startup window.
-    unknown: '',
+    // 'unknown' = first scan hasn't completed yet. Render the same shape as
+    // 'clean' but in the muted grey returned by statusColor() so the row
+    // says "I don't know yet" instead of lying with a red ✕.
+    unknown: '●',
   };
-  return map[status] || '?';
+  // Hasownproperty test rather than `||` so a deliberately-empty mapping
+  // value would be respected (none today, but defensive against future use).
+  return Object.prototype.hasOwnProperty.call(map, status) ? map[status] : '?';
 }


### PR DESCRIPTION
Closes #56

Eight small GUI UX tweaks plus three follow-ups discovered during smoke testing. All under `cmd/gui/frontend/src/` — Svelte template + CSS + a couple of tiny JS reactivity tweaks; no backend changes, no Wails bindings, no test changes.

## What changed

- **No text selection on the chrome.** `:global(body)` defaults to `user-select: none`; `input`, `textarea`, `[contenteditable]`, `pre`, `code`, and any element tagged `.selectable` opt back in. Drag-select and Ctrl-A no longer light up every label in the window.
- **Workspace membership chip → left of clone name, no count.** The icon alone signals membership; hover title still lists the workspaces.
- **Workspace chip becomes the open action.** Clicking it always toggles a small popover anchored above the badge — same UX whether the clone belongs to one workspace or several. Selecting an entry calls `openWorkspace(key)` AND dismisses the popover. Outside-click and ESC also dismiss. Mirrors the existing `pr-popover` pattern. Negative margins on the wrap claw back the row's flex gap so the badge sits flush instead of looking like a 50px-wide gutter. Popover anchors *above* so bottom-row clicks don't get clipped.
- **LauncherMenu cleanup.** The "📦 Open workspace ▸" submenu and its `workspaceKeys` / `onOpenWorkspace` props are gone — the badge is now the entry point.
- **Top-bar tagline gone.** Frees ~120px next to the brand.
- **Icon select toggle (☐ / ☑) replaces the "Select clones" text button**, sitting in the top bar immediately after the trash icon. Switching to Mirrors / Workspaces clears selection mode.
- **Selection actions collapsed into the tab-bar row.** No more sticky "N clones selected" banner — when one or more clones are ticked, `[+ Workspace] [Clear]` appear inline on the right of the Accounts tab row. Counter dropped (per-row checkboxes already show what's selected).
- **PR / Review badges → left of Synced/Pending + Pull.** Final left-to-right order on a clone row: `[other content] → [PR / Review] → [Synced/Pending + Pull] → [sync icon] → [kebab]`.
- **Settings:** rename "PR / review badges" → "PR / reviews"; rename "Include drafts in 📝" → "Include drafts" and put both toggles on the same `.settings-row`. Existing `{#if $prSettings.enabled}` guard preserved on the drafts toggle.
- **Startup window no longer flashes "Error".** Default repo state is now `'unknown'` (was `'error'`), with a grey `●` placeholder dot, no status text on the right, and a spinning fetch icon to signal "checking…". Once the first scan resolves, rows populate normally. Defensive dedup of duplicate workspace members on `config.Load` was already in main.
- **Fetch All hardening.** `runFetchAll` now `await`s `bridge.fetchAllRepos()` inside a try/catch and surfaces backend errors into the `last <time>` field in Settings (silently swallowed before). `last <time>` now renders with seconds (`HH:MM:SS`) since fetch loops complete in well under a minute.

## Known follow-up

The Fetch All animation does not paint on Windows / WebView2 (works on macOS WebKit and Linux WebKit2GTK). Backend events appear coalesced. Tracked separately in #57 — out of scope for this PR. The hardening above (await + try/catch + lastFetchTime with seconds) makes the bug observable, which is what surfaced it.

## Test plan

- [ ] Drag-select on cards / top bar / tab bar / repo rows produces no selection. Selecting text inside an `<input>` or `<textarea>` still works.
- [ ] The workspace chip renders on the left of the clone name, no number, with hover title listing the workspaces.
- [ ] Clicking the chip — on a clone with one or several memberships — opens the popover above the badge listing every workspace. Clicking an entry opens that workspace AND dismisses the popover. Outside-click and ESC also dismiss.
- [ ] LauncherMenu's "📦 Open workspace ▸" submenu is gone.
- [ ] Top bar shows no "accounts & clones" tagline.
- [ ] Top bar shows the trash icon followed by a checkbox-style icon that toggles selection mode (☐ off, ☑ on). Switching tabs clears selection.
- [ ] On the Accounts tab in selection mode, ticking ≥1 clone shows `[+ Workspace] [Clear]` on the right of the tab row. No separate sticky banner.
- [ ] PR / Review badges render to the left of Synced/Pending on every repo row (when PR badges are enabled).
- [ ] Settings shows a single row `PR / reviews [toggle]   Include drafts [toggle]`.
- [ ] At startup every row shows a grey dot, no Error text. The fetch icon spins to signal "checking…". Rows populate normally once the first scan completes.
- [ ] On macOS / Linux, Fetch All animates the top-bar icon and per-row icons one by one and updates `last <HH:MM:SS>` in Settings. (On Windows the timestamp updates but the spinner does not — see #57.)
- [ ] No regressions in existing kebab actions, Accounts/Mirrors/Workspaces tabs, or CLI commands.