### PR TITLE
GUI/Mirrors: progress spinner on Setup + neutral "needs setup" state

### DIFF
--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -427,11 +427,13 @@ type MirrorStatusResult struct {
 	OriginHead string `json:"originHead"`
 	BackupHead string `json:"backupHead"`
 	Warning    string `json:"warning"`
+	NeedsSetup bool   `json:"needsSetup"`
 	Error      string `json:"error"`
 }
 
 // MirrorSetupResult is sent to the frontend after a mirror setup attempt.
 type MirrorSetupResult struct {
+	MirrorKey    string `json:"mirrorKey"`
 	RepoKey      string `json:"repoKey"`
 	Created      bool   `json:"created"`
 	Mirrored     bool   `json:"mirrored"`
@@ -4111,6 +4113,7 @@ func (a *App) GetMirrorStatus(mirrorKey string) {
 				OriginHead: r.OriginHead,
 				BackupHead: r.BackupHead,
 				Warning:    r.Warning,
+				NeedsSetup: r.NeedsSetup,
 				Error:      r.Error,
 			})
 		}
@@ -4120,6 +4123,8 @@ func (a *App) GetMirrorStatus(mirrorKey string) {
 
 // SetupMirrorRepo runs API setup for a single mirror repo.
 // Runs async; emits "mirror:setup:done" event with MirrorSetupResult.
+// On success, stamps MirrorRepo.LastSync so CheckStatus can tell "never set up"
+// from "set up and target is genuinely missing" (issue #59).
 func (a *App) SetupMirrorRepo(mirrorKey, repoKey string) {
 	go func() {
 		a.mu.Lock()
@@ -4131,6 +4136,7 @@ func (a *App) SetupMirrorRepo(mirrorKey, repoKey string) {
 
 		r := mirror.SetupMirror(ctx, cfg, mirrorKey, repoKey)
 		result := MirrorSetupResult{
+			MirrorKey:    mirrorKey,
 			RepoKey:      r.RepoKey,
 			Created:      r.Created,
 			Mirrored:     r.Mirrored,
@@ -4139,7 +4145,18 @@ func (a *App) SetupMirrorRepo(mirrorKey, repoKey string) {
 			Error:        r.Error,
 		}
 
-		_ = r.Error // result is emitted via event below
+		if r.Error == "" {
+			a.mu.Lock()
+			if m, ok := a.cfg.Mirrors[mirrorKey]; ok {
+				if mr, ok := m.Repos[repoKey]; ok {
+					mr.LastSync = time.Now().UTC().Format(time.RFC3339)
+					m.Repos[repoKey] = mr
+					a.cfg.Mirrors[mirrorKey] = m
+					_ = a.saveConfig()
+				}
+			}
+			a.mu.Unlock()
+		}
 
 		wailsrt.EventsEmit(a.ctx, "mirror:setup:done", result)
 	}()

--- a/cmd/gui/frontend/src/App.svelte
+++ b/cmd/gui/frontend/src/App.svelte
@@ -1412,6 +1412,9 @@
 
   // ── Mirrors ──
   let mirrorChecking: Record<string, boolean> = {};
+  // Per-row "setup in progress" flag, keyed by `${mirrorKey}/${repoKey}`.
+  // Set before calling bridge.setupMirrorRepo, cleared on the mirror:setup:done event.
+  let mirrorSettingUp: Record<string, boolean> = {};
   let addMirrorGroupModal = false;
   let addMirrorRepoModal: string | null = null; // holds mirrorKey
   let deleteMirrorGroupConfirm: string | null = null;
@@ -1789,6 +1792,7 @@
   }
 
   function mirrorStatusColor(repo: MirrorRepo, live: MirrorStatusResult | undefined, theme: string): string {
+    if (live?.needsSetup) return statusColor('not cloned', theme); // neutral — row has never been set up
     if (live?.error) return statusColor('error', theme);
     if (live?.syncStatus === 'synced') return statusColor('clean', theme);
     if (live?.syncStatus === 'behind') return statusColor('behind', theme);
@@ -1798,6 +1802,7 @@
   }
 
   function mirrorStatusSymbol(repo: MirrorRepo, live: MirrorStatusResult | undefined): string {
+    if (live?.needsSetup) return '○';
     if (live?.error) return '✕';
     if (live?.syncStatus === 'synced') return '●';
     if (live?.syncStatus === 'behind') return '↓';
@@ -1808,6 +1813,7 @@
 
   /** Summarize live mirror status in a short, user-friendly string. */
   function mirrorStatusText(repo: MirrorRepo, live: MirrorStatusResult | undefined): string {
+    if (live?.needsSetup) return 'needs setup';
     if (live?.error) return friendlyMirrorError(live.error);
     if (live?.syncStatus === 'synced') return 'Synced OK';
     if (live?.syncStatus === 'behind') return 'Backup is behind origin';
@@ -1831,6 +1837,7 @@
         total++;
         const live = $mirrorStates[`${key}/${repoKey}`];
         if (!live) unchecked++;
+        else if (live.needsSetup) unchecked++;
         else if (live.error) error++;
         else active++;
       }
@@ -1865,6 +1872,10 @@
       mirrorCredWarning = credCheck;
       return;
     }
+    // Flip the per-row spinner on before firing the async bridge call. Cleared
+    // in the mirror:setup:done handler below.
+    const key = `${mirrorKey}/${repoKey}`;
+    mirrorSettingUp = { ...mirrorSettingUp, [key]: true };
     await bridge.setupMirrorRepo(mirrorKey, repoKey);
   }
 
@@ -2424,6 +2435,13 @@
 
     events.on('mirror:setup:done', async (data: any) => {
       mirrorSetupResultModal = data;
+      // Clear the per-row spinner. The Go side now emits the mirrorKey too
+      // (issue #59) so we can key off ${mirrorKey}/${repoKey} directly.
+      if (data?.mirrorKey && data?.repoKey) {
+        const key = `${data.mirrorKey}/${data.repoKey}`;
+        const { [key]: _removed, ...rest } = mirrorSettingUp;
+        mirrorSettingUp = rest;
+      }
       $configStore = await bridge.reloadConfig();
       checkAllMirrorStatus();
     });
@@ -3431,11 +3449,20 @@
         {#each (mir.repoOrder && mir.repoOrder.length > 0 ? mir.repoOrder : Object.keys(mir.repos)) as repoName}
           {@const repo = mir.repos[repoName]}
           {@const live = $mirrorStates[`${mirrorKey}/${repoName}`]}
+          {@const settingUp = !!mirrorSettingUp[`${mirrorKey}/${repoName}`]}
           <div class="mirror-row">
-            <span class="mirror-dot" style="color:{mirrorStatusColor(repo, live, $themeStore)}">{mirrorStatusSymbol(repo, live)}</span>
+            {#if settingUp}
+              <span class="mirror-dot"><div class="spinner-sm"></div></span>
+            {:else}
+              <span class="mirror-dot" style="color:{mirrorStatusColor(repo, live, $themeStore)}">{mirrorStatusSymbol(repo, live)}</span>
+            {/if}
             <span class="mirror-repo-name">{repoName}</span>
             <span class="mirror-direction">{@html mirrorDirLabelHtml(repo, mir)}</span>
-            <span class="mirror-status-text" style="color:{mirrorStatusColor(repo, live, $themeStore)}">{mirrorStatusText(repo, live)}</span>
+            {#if settingUp}
+              <span class="mirror-status-text">setting up…</span>
+            {:else}
+              <span class="mirror-status-text" style="color:{mirrorStatusColor(repo, live, $themeStore)}">{mirrorStatusText(repo, live)}</span>
+            {/if}
             {#if live?.warning}
               <span class="mirror-warning" title={live.warning}>⚠</span>
             {/if}
@@ -3443,7 +3470,7 @@
               {@const errAcct = live.error.replace('missing API token in ', '')}
               <button class="btn-sm btn-fix" on:click={() => openTokenSetup(errAcct)} title="Set up API token for {errAcct}">Fix credentials</button>
             {:else if !deleteMode}
-              <button class="btn-sm btn-setup" on:click={() => setupMirrorRepo(mirrorKey, repoName)}>Setup</button>
+              <button class="btn-sm btn-setup" on:click={() => setupMirrorRepo(mirrorKey, repoName)} disabled={settingUp}>Setup</button>
             {/if}
             {#if deleteMode}
               <button class="btn-sm btn-danger" on:click={() => deleteMirrorRepoConfirm = { mirrorKey, repoKey: repoName }}>✕</button>

--- a/cmd/gui/frontend/src/lib/types.ts
+++ b/cmd/gui/frontend/src/lib/types.ts
@@ -71,10 +71,12 @@ export interface MirrorStatusResult {
   originHead: string;
   backupHead: string;
   warning: string;
+  needsSetup: boolean;
   error: string;
 }
 
 export interface MirrorSetupResult {
+  mirrorKey: string;
   repoKey: string;
   created: boolean;
   mirrored: boolean;

--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -24,5 +24,6 @@ type StatusResult struct {
 	OriginHead string // short SHA of origin when behind
 	BackupHead string // short SHA of backup when behind
 	Warning    string // non-empty for warnings (e.g., repo is public)
+	NeedsSetup bool   // target 404 on a row that has never been set up yet — render as neutral "needs setup", not a red error
 	Error      string // non-empty on failure
 }

--- a/pkg/mirror/status.go
+++ b/pkg/mirror/status.go
@@ -95,6 +95,22 @@ func CheckStatus(ctx context.Context, cfg *config.Config, mirrorKey, repoKey str
 	dstInfo, err := backupInfo.GetRepoInfo(ctx, backupAcct.URL, backupToken, backupAcct.Username, backupOwner, backupName)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
+			// A 404 on the backup side means one of two things:
+			//   1. The user has never completed setup for this row yet — the
+			//      target is supposed to be missing. Render as neutral
+			//      "needs setup", not a red error.
+			//   2. Setup was done previously and the target was since deleted
+			//      on the provider — a genuine error the user should see.
+			//
+			// mr.LastSync is populated on successful setup (see cmd/gui/app.go
+			// SetupMirrorRepo); an empty value means branch 1. Legacy configs
+			// created before LastSync was written will land in branch 1 as
+			// well — the false-neutral state self-heals on the first click of
+			// Setup, which is acceptable for that rare case.
+			if mr.LastSync == "" {
+				base.NeedsSetup = true
+				return base
+			}
 			base.Error = "target repo does not exist on " + backupKey
 			return base
 		}

--- a/pkg/mirror/status_test.go
+++ b/pkg/mirror/status_test.go
@@ -1,0 +1,100 @@
+package mirror
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LuisPalacios/gitbox/pkg/config"
+	"github.com/LuisPalacios/gitbox/pkg/credential"
+)
+
+// TestCheckStatus_404_NeedsSetup_vs_Error covers issue #59: a 404 from the
+// backup's GetRepoInfo should render as neutral "needs setup" on rows that
+// have never been set up (LastSync == ""), and as the red "target repo does
+// not exist" error on rows that were set up previously (LastSync populated).
+func TestCheckStatus_404_NeedsSetup_vs_Error(t *testing.T) {
+	// Origin server: responds OK for GetRepoInfo so we only exercise the
+	// backup 404 branching.
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/repos/org/repo":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"default_branch":"main","private":true}`))
+		case "/api/v3/repos/org/repo/branches/main":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"abc123","commit":{"author":{"date":"2025-01-01T00:00:00Z"}}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer origin.Close()
+
+	// Backup server: always 404 on the repo endpoint — simulating "target
+	// does not exist on backup provider".
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer backup.Close()
+
+	// Token env vars so credential.ResolveToken / ResolveAPIToken find PATs
+	// without hitting the keyring.
+	t.Setenv(credential.EnvVarName("origin-acct"), "tok-origin")
+	t.Setenv(credential.EnvVarName("backup-acct"), "tok-backup")
+
+	makeCfg := func(lastSync string) *config.Config {
+		return &config.Config{
+			Version: 2,
+			Accounts: map[string]config.Account{
+				"origin-acct": {
+					Provider: "github", URL: origin.URL, Username: "alice",
+					DefaultCredentialType: "token",
+				},
+				"backup-acct": {
+					Provider: "github", URL: backup.URL, Username: "bob",
+					DefaultCredentialType: "token",
+				},
+			},
+			Mirrors: map[string]config.Mirror{
+				"grp": {
+					AccountSrc: "origin-acct",
+					AccountDst: "backup-acct",
+					Repos: map[string]config.MirrorRepo{
+						"org/repo": {
+							Direction: "push",
+							Origin:    "src",
+							LastSync:  lastSync,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	ctx := context.Background()
+
+	// Branch 1: never set up → NeedsSetup true, no Error.
+	t.Run("never set up, target 404 → NeedsSetup", func(t *testing.T) {
+		cfg := makeCfg("")
+		r := CheckStatus(ctx, cfg, "grp", "org/repo")
+		if !r.NeedsSetup {
+			t.Errorf("NeedsSetup = false, want true")
+		}
+		if r.Error != "" {
+			t.Errorf("Error = %q, want empty (new row 404 must not surface as error)", r.Error)
+		}
+	})
+
+	// Branch 2: previously set up → Error, NeedsSetup false.
+	t.Run("previously set up, target 404 → Error", func(t *testing.T) {
+		cfg := makeCfg("2025-01-01T00:00:00Z")
+		r := CheckStatus(ctx, cfg, "grp", "org/repo")
+		if r.NeedsSetup {
+			t.Errorf("NeedsSetup = true, want false (previously-set-up row must surface the missing target)")
+		}
+		if r.Error != "target repo does not exist on backup-acct" {
+			t.Errorf("Error = %q, want %q", r.Error, "target repo does not exist on backup-acct")
+		}
+	})
+}


### PR DESCRIPTION
Closes #59

## What changed
- New mirror rows stuck as "unchecked" for seconds now show a spinner and
  "setting up…" text, with the Setup button disabled, until the existing
  `mirror:setup:done` event fires.
- The 404 "target repo does not exist" error on the backup side is now
  split on `MirrorRepo.LastSync`: empty (never set up) renders a neutral
  "needs setup" row with a prominent Setup button; populated (set up and
  target since deleted) keeps the existing red error.
- `SetupMirrorRepo` stamps `LastSync` on success so new setups move out
  of the "needs setup" branch on the next status refresh.
- Adds `pkg/mirror/status_test.go` covering both branches via httptest.

## Test plan
- [ ] Add a mirror repo with "Set up immediately via API" on: row shows spinner + disabled Setup, then flips to real status when done.
- [ ] Add a mirror repo without auto-setup: row renders neutral `○ needs setup`, no red error. Click Setup → spinner → resolved status.
- [ ] Existing healthy rows still render `● Synced OK` (no regression).
- [ ] A row set up previously whose target was then deleted on the provider still shows the red `target repo does not exist on <accountKey>` error.
- [ ] `go vet ./...` + `go test -short ./...` green on macOS/arm64.