### PR TITLE
fix(credential): accept absolute-path GCM helper and helper reset chains

### DIFF
--- a/pkg/credential/gcm_config.go
+++ b/pkg/credential/gcm_config.go
@@ -2,6 +2,8 @@ package credential
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/LuisPalacios/gitbox/pkg/config"
 	"github.com/LuisPalacios/gitbox/pkg/git"
@@ -71,22 +73,87 @@ func CheckGlobalGCMConfig(cfg *config.Config) GlobalGCMConfigStatus {
 	s := GlobalGCMConfigStatus{}
 	s.ExpectedHelper, s.ExpectedCredentialStore = expectedGCMDefaults(cfg)
 
-	if v, err := git.GlobalConfigGet("credential.helper"); err == nil && v != "" {
+	// credential.helper is a multi-value key. Apply git's reset semantics (an
+	// empty value clears everything listed before it) to get the effective
+	// helper chain. The macOS Homebrew GCM cask's `git-credential-manager
+	// configure` appends an absolute path after a reset, leaving a chain like
+	// ["manager", "", "/usr/local/share/gcm-core/git-credential-manager"].
+	values, _ := git.GlobalConfigGetAll("credential.helper")
+	eff := effectiveHelpers(values)
+	if len(eff) > 0 {
 		s.HasHelper = true
-		s.HelperValue = v
+		s.HelperValue = eff[len(eff)-1]
 	}
 	if v, err := git.GlobalConfigGet("credential.credentialStore"); err == nil && v != "" {
 		s.HasCredentialStore = true
 		s.CredentialStoreValue = v
 	}
 
-	if !s.HasHelper || s.HelperValue != s.ExpectedHelper {
+	if !s.HasHelper || !helperSatisfies(eff, s.ExpectedHelper) {
 		s.NeedsFix = true
 	}
 	if !s.HasCredentialStore || s.CredentialStoreValue != s.ExpectedCredentialStore {
 		s.NeedsFix = true
 	}
 	return s
+}
+
+// effectiveHelpers reduces a multi-value credential.helper list to the helpers
+// git actually uses, honoring its reset rule: an empty value discards every
+// helper listed before it; non-empty values are appended.
+func effectiveHelpers(values []string) []string {
+	var eff []string
+	for _, v := range values {
+		if strings.TrimSpace(v) == "" {
+			eff = nil
+			continue
+		}
+		eff = append(eff, v)
+	}
+	return eff
+}
+
+// helperSatisfies reports whether the effective helper chain meets expectations.
+// When the expected helper is Git Credential Manager (the default), any helper
+// that resolves to GCM counts — including an absolute path to the binary, the
+// form `git-credential-manager configure` writes on macOS. When the expected
+// helper is something else (a cfg override like "store"), an exact match is
+// required.
+func helperSatisfies(eff []string, expected string) bool {
+	expectGCM := isGCMHelper(expected)
+	for _, h := range eff {
+		if expectGCM {
+			if isGCMHelper(h) {
+				return true
+			}
+		} else if strings.TrimSpace(h) == strings.TrimSpace(expected) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGCMHelper reports whether a credential.helper value refers to Git Credential
+// Manager, whether written as the short name git resolves on PATH ("manager",
+// legacy "manager-core") or as an absolute/relative path to the binary (e.g.
+// /usr/local/share/gcm-core/git-credential-manager, as the macOS Homebrew cask's
+// `git-credential-manager configure` writes).
+func isGCMHelper(value string) bool {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return false
+	}
+	// Normalize Windows separators so a path written with backslashes is
+	// recognized even when checked on a non-Windows host (and in tests).
+	v = strings.ReplaceAll(v, "\\", "/")
+	base := strings.ToLower(path.Base(v))
+	base = strings.TrimSuffix(base, ".exe")
+	switch base {
+	case "manager", "manager-core", "git-credential-manager":
+		return true
+	default:
+		return false
+	}
 }
 
 // FixGlobalGCMConfig repairs the global gitconfig so GCM-backed fills work:

--- a/pkg/credential/gcm_config_test.go
+++ b/pkg/credential/gcm_config_test.go
@@ -109,6 +109,79 @@ func TestCheckGlobalGCMConfig_OK(t *testing.T) {
 	}
 }
 
+// On macOS, the Homebrew GCM cask's `git-credential-manager configure` appends
+// an absolute path to the binary after an empty reset entry, leaving a chain
+// like ["manager", "", "/usr/local/share/gcm-core/git-credential-manager"].
+// That is a valid GCM wiring and must NOT be flagged for fixing.
+func TestCheckGlobalGCMConfig_AbsolutePathHelperIsOK(t *testing.T) {
+	isolateGlobalGitconfig(t)
+	// Reproduce the real-world multi-value chain via --add.
+	if err := git.GlobalConfigSet("credential.helper", "manager"); err != nil {
+		t.Fatalf("seeding helper: %v", err)
+	}
+	if err := git.GlobalConfigAdd("credential.helper", ""); err != nil {
+		t.Fatalf("seeding reset: %v", err)
+	}
+	const absPath = "/usr/local/share/gcm-core/git-credential-manager"
+	if err := git.GlobalConfigAdd("credential.helper", absPath); err != nil {
+		t.Fatalf("seeding abs helper: %v", err)
+	}
+	if err := git.GlobalConfigSet("credential.credentialStore", DefaultCredentialStore()); err != nil {
+		t.Fatalf("seeding store: %v", err)
+	}
+
+	s := CheckGlobalGCMConfig(&config.Config{})
+	if !s.HasHelper || s.HelperValue != absPath {
+		t.Errorf("helper state = (%v,%q), want (true,%q)", s.HasHelper, s.HelperValue, absPath)
+	}
+	if s.NeedsFix {
+		t.Errorf("NeedsFix = true, want false (absolute GCM path is a valid helper)")
+	}
+}
+
+// A reset entry that clears the only helper leaves no effective helper — that
+// must be flagged.
+func TestCheckGlobalGCMConfig_ResetClearsHelper(t *testing.T) {
+	isolateGlobalGitconfig(t)
+	if err := git.GlobalConfigSet("credential.helper", "manager"); err != nil {
+		t.Fatalf("seeding helper: %v", err)
+	}
+	if err := git.GlobalConfigAdd("credential.helper", ""); err != nil {
+		t.Fatalf("seeding reset: %v", err)
+	}
+
+	s := CheckGlobalGCMConfig(&config.Config{})
+	if s.HasHelper {
+		t.Errorf("HasHelper = true, want false (reset cleared the only helper)")
+	}
+	if !s.NeedsFix {
+		t.Errorf("NeedsFix = false, want true (no effective helper)")
+	}
+}
+
+func TestIsGCMHelper(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"manager", true},
+		{"manager-core", true},
+		{"git-credential-manager", true},
+		{"/usr/local/share/gcm-core/git-credential-manager", true},
+		{"C:\\Program Files\\Git\\mingw64\\bin\\git-credential-manager.exe", true},
+		{"  manager  ", true},
+		{"", false},
+		{"store", false},
+		{"cache", false},
+		{"/usr/bin/git-credential-store", false},
+	}
+	for _, tc := range cases {
+		if got := isGCMHelper(tc.value); got != tc.want {
+			t.Errorf("isGCMHelper(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
 func TestCheckGlobalGCMConfig_RespectsCfgOverrides(t *testing.T) {
 	isolateGlobalGitconfig(t)
 	// Cfg overrides the default helper to "store" — "store" should then be

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -530,6 +530,12 @@ func GlobalConfigSet(key, value string) error {
 	return run(".", "config", "--global", key, value)
 }
 
+// GlobalConfigAdd appends a value to a (possibly multi-valued) global git config
+// key without overwriting existing values.
+func GlobalConfigAdd(key, value string) error {
+	return run(".", "config", "--global", "--add", key, value)
+}
+
 // GlobalConfigGet reads a global git config value.
 func GlobalConfigGet(key string) (string, error) {
 	out, err := output(".", "config", "--global", "--get", key)
@@ -537,6 +543,26 @@ func GlobalConfigGet(key string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(out), nil
+}
+
+// GlobalConfigGetAll reads every value of a (possibly multi-valued) global git
+// config key, in the order git stores them. Empty values are preserved — they
+// matter for credential.helper, where an empty entry resets the helper chain.
+// Returns an empty slice (nil error) when the key is absent.
+func GlobalConfigGetAll(key string) ([]string, error) {
+	out, err := output(".", "config", "--global", "--get-all", key)
+	if err != nil {
+		// git config --get-all exits with code 1 when the key does not exist.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	// git prints each value followed by a newline; strip the single trailing
+	// newline, then split. An all-empty result means one empty-string value.
+	out = strings.TrimSuffix(out, "\n")
+	return strings.Split(out, "\n"), nil
 }
 
 // GlobalConfigUnset removes a key from global git config.


### PR DESCRIPTION
## Problem

On macOS, the global `~/.gitconfig` GCM check raised a false "missing GCM settings" banner even when GCM was correctly installed and working.

`CheckGlobalGCMConfig` compared `credential.helper` literally against `"manager"` and read only a single value via `git config --get`. The Homebrew GCM cask's `git-credential-manager configure` writes the absolute binary path after an empty reset entry, producing a multi-value chain like:

```
credential.helper manager
credential.helper                                                    # empty: resets the chain
credential.helper /usr/local/share/gcm-core/git-credential-manager  # effective helper
```

git's effective helper is the absolute path (works fine), but gitbox saw `path != "manager"` and flagged it. Windows was unaffected because GCM wires the short `manager` name there.

## Fix

- Read the full multi-value helper list via new `git.GlobalConfigGetAll`.
- Apply git's reset semantics (an empty value clears prior helpers) to compute the effective chain.
- Accept any effective helper that resolves to GCM: the short names `manager` / `manager-core`, or an absolute/relative path whose basename is `git-credential-manager[.exe]`.
- A non-GCM cfg override still requires an exact match. `credentialStore` handling is unchanged.

Adds `git.GlobalConfigGetAll` / `git.GlobalConfigAdd`.

## Tests

- New unit tests cover the macOS reset+abspath chain, a reset that clears the only helper, and `isGCMHelper` across short names and Windows/Unix paths.
- `go vet ./...` clean; `go test ./pkg/credential/` passes.

## Verification

Reproduced against the exact gitconfig chain above: `NeedsFix` is now `false`, banner gone, GCM still functional.